### PR TITLE
Fix session bundle restore for widget state

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,18 +73,28 @@ def render_brand_header() -> None:
     st.divider()
 
 
-# Apply brand styles and sidebar logo once
-_inject_brand_styles()
-if LOGO_FULL.exists() or LOGO_ICON.exists():
-    st.sidebar.image(str(LOGO_FULL if LOGO_FULL.exists() else LOGO_ICON), use_container_width=True)
-
-
 def format_currency(value: float) -> str:
     return f"${value:,.0f}"
 
 
 def _get_state(key: str, default):
     return st.session_state.get(key, default)
+
+
+def _apply_pending_state_updates() -> None:
+    """Apply any deferred session state updates before widgets render."""
+
+    pending = st.session_state.pop("_pending_state_update", None)
+    if isinstance(pending, dict):
+        for k, v in pending.items():
+            st.session_state[k] = v
+
+
+# Apply brand styles and sidebar logo once
+_inject_brand_styles()
+_apply_pending_state_updates()
+if LOGO_FULL.exists() or LOGO_ICON.exists():
+    st.sidebar.image(str(LOGO_FULL if LOGO_FULL.exists() else LOGO_ICON), use_container_width=True)
 
 
 def _format_date_badges(dates: list[pd.Timestamp | str]) -> str:
@@ -792,8 +802,8 @@ def _apply_session_bundle(file_like) -> None:
         # state
         try:
             state = json.loads(zf.read("state.json"))
-            for k, v in state.items():
-                st.session_state[k] = v
+            if isinstance(state, dict):
+                st.session_state["_pending_state_update"] = state
         except KeyError:
             pass
 


### PR DESCRIPTION
## Summary
- add a helper to apply any deferred session state updates before widgets render
- defer applying saved widget-backed values until after a rerun when loading a session bundle to avoid Streamlit modification errors

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d60ae7eef48327b9708126ff854c47