### PR TITLE
Remove unused UI helpers

### DIFF
--- a/substack_analyzer/ui.py
+++ b/substack_analyzer/ui.py
@@ -60,17 +60,3 @@ def format_date_badges(dates) -> str:
             f"{label}</span>"
         )
     return "".join(items)
-
-
-def number_input_state(label: str, *, key: str, default_value, **kwargs):
-    kwargs["key"] = key
-    if key not in st.session_state:
-        kwargs["value"] = default_value
-    return st.number_input(label, **kwargs)
-
-
-def slider_state(label: str, *, key: str, default_value, **kwargs):
-    kwargs["key"] = key
-    if key not in st.session_state:
-        kwargs["value"] = default_value
-    return st.slider(label, **kwargs)


### PR DESCRIPTION
## Summary
- remove the unused Streamlit number/slider helpers from the shared UI module to eliminate dead code

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddf45e2fbc8327869eff561c99d919