### PR TITLE
Extract shared month-end index normalizer

### DIFF
--- a/scripts/run_headless.py
+++ b/scripts/run_headless.py
@@ -28,6 +28,7 @@ import streamlit as st
 from substack_analyzer.analysis import build_events_features, compute_estimates, read_series
 from substack_analyzer.calibration import fit_piecewise_logistic
 from substack_analyzer.detection import detect_change_points
+from substack_analyzer.utils import ensure_month_end_index
 
 
 def _open_file(path: Optional[str]) -> Optional[object]:
@@ -62,13 +63,6 @@ def _read_events_csv(path: Optional[str]) -> pd.DataFrame:
     return out
 
 
-def _ensure_month_end_index(s: pd.Series) -> pd.Series:
-    s = s.copy()
-    s.index = pd.to_datetime(s.index).to_period("M").to_timestamp("M")
-    s = s.sort_index()
-    return s
-
-
 def run(
     all_path: Optional[str],
     all_has_header: bool,
@@ -93,11 +87,11 @@ def run(
     if all_path:
         with _open_file(all_path) as f_all:
             total = read_series(f_all, all_has_header, all_date_col, all_count_col)
-            total = _ensure_month_end_index(total)
+            total = ensure_month_end_index(total)
     if paid_path:
         with _open_file(paid_path) as f_paid:
             paid = read_series(f_paid, paid_has_header, paid_date_col, paid_count_col)
-            paid = _ensure_month_end_index(paid)
+            paid = ensure_month_end_index(paid)
 
     if total is None and paid is None:
         raise SystemExit("Provide at least one of --all or --paid")

--- a/substack_analyzer/calibration.py
+++ b/substack_analyzer/calibration.py
@@ -4,6 +4,8 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
+from substack_analyzer.utils import ensure_month_end_index
+
 
 @dataclass(frozen=True)
 class PiecewiseLogisticFit:
@@ -18,16 +20,6 @@ class PiecewiseLogisticFit:
     r2_on_deltas: float
     gamma_exog: float | None = None
     gamma_intercept: float = 0.0
-
-
-def _ensure_month_end_index(series: pd.Series) -> pd.Series:
-    s = series.dropna().copy()
-    if not isinstance(s.index, pd.DatetimeIndex):
-        raise ValueError("Series must have a DatetimeIndex")
-    # Normalize to month end to align with app import convention
-    s.index = s.index.to_period("M").to_timestamp("M")
-    s = s.sort_index()
-    return s
 
 
 def _segments_from_breakpoints(n: int, breakpoints: Sequence[int]) -> list[tuple[int, int]]:
@@ -88,7 +80,7 @@ def fit_piecewise_logistic(
     - γ_pulse, γ_step, γ_exog are global coefficients.
     - Parameters are estimated by OLS on ΔS_t for each candidate K; pick K with lowest SSE.
     """
-    input_series = _ensure_month_end_index(total_series)
+    input_series = ensure_month_end_index(total_series)
     if input_series.size < 4:
         raise ValueError("Need at least 4 months of data to fit the model")
     # Construct deltas and base regressor X_t(K)
@@ -266,7 +258,7 @@ def fitted_series_from_params(
 
     Applies the same discrete dynamic used in fitting, aligned to month-end index.
     """
-    s = _ensure_month_end_index(total_series)
+    s = ensure_month_end_index(total_series)
     if s.size == 0:
         return s
 

--- a/substack_analyzer/plot_utils.py
+++ b/substack_analyzer/plot_utils.py
@@ -8,7 +8,8 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from substack_analyzer.calibration import PiecewiseLogisticFit, _ensure_month_end_index
+from substack_analyzer.calibration import PiecewiseLogisticFit
+from substack_analyzer.utils import ensure_month_end_index
 
 
 def plot_fit_vs_actual(
@@ -40,7 +41,7 @@ def plot_fit_vs_actual(
         The Axes object for further customization.
     """
 
-    actual = _ensure_month_end_index(input_series).astype(float)
+    actual = ensure_month_end_index(input_series).astype(float)
     fitted = fit.fitted_series.reindex(actual.index).astype(float)
 
     if title is None:

--- a/substack_analyzer/utils.py
+++ b/substack_analyzer/utils.py
@@ -1,0 +1,21 @@
+"""Shared utility helpers for series handling."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ensure_month_end_index(series: pd.Series) -> pd.Series:
+    """Return a copy of ``series`` indexed on month-end timestamps.
+
+    The Streamlit app and headless runner both normalise monthly aggregates to
+    use month-end ``DatetimeIndex`` values. This helper centralises that logic so
+    callers don't need to duplicate the conversion.
+    """
+
+    s = series.dropna().copy()
+    if not isinstance(s.index, pd.DatetimeIndex):
+        raise ValueError("Series must have a DatetimeIndex")
+    s.index = s.index.to_period("M").to_timestamp("M")
+    s = s.sort_index()
+    return s


### PR DESCRIPTION
## Summary
- add a shared ensure_month_end_index utility for normalising monthly series
- update calibration, plotting, and headless runner modules to reuse the shared helper

## Testing
- pytest *(fails: missing optional matplotlib dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb2f76c4948327aaf10d3a32ffccee