### PR TITLE
Strengthen ads valuable scenario with meaningful exogenous lift

### DIFF
--- a/substack_analyzer/scenarios.py
+++ b/substack_analyzer/scenarios.py
@@ -473,7 +473,9 @@ def scenario_ads_really_valuable():
     exog = features_df["ad_effect_log"].astype(float)
 
     # Build Total series that actually uses exogenous effect (positive influence)
-    total = synthesize_series_with_exog(idx, K=20000.0, r=0.03, exog=exog, g_exog=0)
+    # Lower the organic growth rate a bit so the ad contribution is a meaningful share
+    # of the month-to-month deltas (g_exog ~= 5 subscribers per unit of ad_effect_log).
+    total = synthesize_series_with_exog(idx, K=20000.0, r=0.02, exog=exog, g_exog=5.0)
 
     return total
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -39,7 +39,7 @@ def test_phase1_ads_really_valuable_phase1_json():
     assert 10000 < carrying_capacity < 30000, f"carrying_capacity {carrying_capacity} is not in range"
     assert 0.0 <= gamma_step <= 0.50, f"gamma_step {gamma_step} is not in range"
     assert 0.0 <= gamma_pulse <= 1, f"gamma_pulse {gamma_pulse} is not in range"
-    assert 0.05 <= gamma_exog <= 0.2, f"gamma_exog {gamma_exog} is not in range"  # why is this so low?
+    assert 4.0 <= gamma_exog <= 6.5, f"gamma_exog {gamma_exog} is not in range"
 
 
 def test_phase1_ads_have_no_effect_phase1_json():


### PR DESCRIPTION
## Summary
- update the ads-really-valuable scenario to include a strong exogenous ad response
- tighten the associated test to expect a materially positive gamma_exog fit

## Testing
- pytest tests/test_scenarios.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a5ac23f48327865a646e7122fb5f)