### PR TITLE
Fix model fit parameter sidebar rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ from substack_analyzer.persistence import (
     export_phase_one_json,
 )
 from substack_analyzer.types import AdSpendSchedule, SimulationInputs
+from substack_analyzer.utils import coerce_list
 from substack_analyzer.ui import format_currency as ui_format_currency
 from substack_analyzer.ui import format_date_badges as ui_format_date_badges
 from substack_analyzer.ui import inject_brand_styles as ui_inject_brand_styles
@@ -861,19 +862,25 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
             if getattr(fit, "gamma_exog", None) is not None and "modelfit_gamma_exog" not in st.session_state:
                 st.session_state["modelfit_gamma_exog"] = float(getattr(fit, "gamma_exog", 0.0))
             if "modelfit_r" not in st.session_state:
-                st.session_state["modelfit_r"] = list(getattr(fit, "segment_growth_rates", []) or [])
+                st.session_state["modelfit_r"] = coerce_list(getattr(fit, "segment_growth_rates", None))
             if "modelfit_intercepts" not in st.session_state:
-                st.session_state["modelfit_intercepts"] = list(getattr(fit, "segment_intercepts", []) or [])
+                st.session_state["modelfit_intercepts"] = coerce_list(getattr(fit, "segment_intercepts", None))
 
             # ----- read current overrides & recompute fitted line with them -----
             def _current_fit_params():
                 fit_obj = st.session_state.get("pwlog_fit")
                 k_val = float(st.session_state.get("modelfit_K", getattr(fit_obj, "carrying_capacity", 0.0) or 0.0))
-                r_list = list(
-                    st.session_state.get("modelfit_r", list(getattr(fit_obj, "segment_growth_rates", []) or []))
+                r_list = coerce_list(
+                    st.session_state.get(
+                        "modelfit_r",
+                        coerce_list(getattr(fit_obj, "segment_growth_rates", None)),
+                    )
                 )
-                intercepts = list(
-                    st.session_state.get("modelfit_intercepts", list(getattr(fit_obj, "segment_intercepts", []) or []))
+                intercepts = coerce_list(
+                    st.session_state.get(
+                        "modelfit_intercepts",
+                        coerce_list(getattr(fit_obj, "segment_intercepts", None)),
+                    )
                 )
                 gp_val = float(
                     st.session_state.get("modelfit_gamma_pulse", getattr(fit_obj, "gamma_pulse", 0.0) or 0.0)
@@ -988,7 +995,12 @@ def _current_fit_params():
     """
     fit_obj = st.session_state.get("pwlog_fit")
     k_val = float(st.session_state.get("modelfit_K", getattr(fit_obj, "carrying_capacity", 0.0) or 0.0))
-    r_list = list(st.session_state.get("modelfit_r", list(getattr(fit_obj, "segment_growth_rates", []) or [])))
+    r_list = coerce_list(
+        st.session_state.get(
+            "modelfit_r",
+            coerce_list(getattr(fit_obj, "segment_growth_rates", None)),
+        )
+    )
     gp_val = float(st.session_state.get("modelfit_gamma_pulse", getattr(fit_obj, "gamma_pulse", 0.0) or 0.0))
     gs_val = float(st.session_state.get("modelfit_gamma_step", getattr(fit_obj, "gamma_step", 0.0) or 0.0))
     gx_val = st.session_state.get("modelfit_gamma_exog", getattr(fit_obj, "gamma_exog", None))
@@ -1118,7 +1130,7 @@ def sidebar_inputs() -> SimulationInputs:
 
     # Brief status: show fitted segment growth rates if available
     fit_side = st.session_state.get("pwlog_fit")
-    seg_rates = list(getattr(fit_side, "segment_growth_rates", []) or [])
+    seg_rates = coerce_list(getattr(fit_side, "segment_growth_rates", None))
     if seg_rates:
         # Prefer live overrides if present
         r_over = st.session_state.get("modelfit_r")
@@ -1360,7 +1372,7 @@ def sidebar_inputs() -> SimulationInputs:
                     )
 
                 # Segment growth rates r_j
-                r_list = list(getattr(fit, "segment_growth_rates", []) or [])
+                r_list = coerce_list(getattr(fit, "segment_growth_rates", None))
                 r_over = []
                 for j, rj in enumerate(r_list, start=1):
                     r_val = number_input_state(

--- a/scripts/run_headless.py
+++ b/scripts/run_headless.py
@@ -37,7 +37,7 @@ from substack_analyzer.analysis import (
 from substack_analyzer.calibration import fit_piecewise_logistic
 from substack_analyzer.detection import detect_change_points
 from substack_analyzer.persistence import export_phase_one_json
-from substack_analyzer.utils import ensure_month_end_index
+from substack_analyzer.utils import coerce_list, ensure_month_end_index
 
 coloredlogs.install(level="DEBUG")
 logger = logging.getLogger("substack_headless")
@@ -382,7 +382,7 @@ def run(
             eq = eq[:-1] + r" + \\gamma_{exog}\\,x_t$"
 
         k_now = getattr(fit, "carrying_capacity", None)
-        r_list = list(getattr(fit, "segment_growth_rates", []) or [])
+        r_list = coerce_list(getattr(fit, "segment_growth_rates", None))
         gp = getattr(fit, "gamma_pulse", None)
         gs = getattr(fit, "gamma_step", None)
         gx = getattr(fit, "gamma_exog", None)

--- a/substack_analyzer/utils.py
+++ b/substack_analyzer/utils.py
@@ -1,5 +1,8 @@
 """Shared utility helpers for series handling."""
 
+from collections.abc import Iterable
+from typing import Any
+
 import pandas as pd
 
 
@@ -17,3 +20,26 @@ def ensure_month_end_index(series: pd.Series) -> pd.Series:
     s.index = s.index.to_period("M").to_timestamp("M")
     s = s.sort_index()
     return s
+
+
+def coerce_list(values: Any) -> list[Any]:
+    """Return ``values`` as a plain ``list``.
+
+    Streamlit session state can hold a variety of container types (including
+    ``numpy`` arrays and pandas objects). ``list(x)`` works for many of these,
+    but it raises when ``x`` does not define truthiness (e.g. a multi-element
+    ``numpy`` array). This helper standardises the conversion so callers don't
+    need to guard every access with ``try/except`` blocks.
+    """
+
+    if values is None:
+        return []
+    if isinstance(values, list):
+        return list(values)
+    if isinstance(values, (tuple, set)):
+        return list(values)
+    if isinstance(values, (str, bytes)):
+        return [values]
+    if isinstance(values, Iterable):
+        return list(values)
+    return [values]


### PR DESCRIPTION
## Summary
- add a reusable helper to safely coerce iterable model parameters into standard Python lists
- update the Streamlit sidebar and headless runner to use the helper so model fit parameters render reliably

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913acb49c3c832783ab0de70eaf2082)