### PR TITLE
Align detection pipeline across app and headless runner

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,14 @@ from substack_analyzer.analysis import (
     read_series,
 )
 from substack_analyzer.calibration import fit_piecewise_logistic, fitted_series_from_params, forecast_piecewise_logistic
-from substack_analyzer.changepoints import breakpoints_to_events, detect_and_classify
+from substack_analyzer.changepoints import (
+    BreakpointEffect,
+    DetectionConfig,
+    DetectionResult,
+    breakpoints_to_events,
+    filter_breakpoints,
+    run_detection,
+)
 from substack_analyzer.detection import compute_segment_slopes, slope_around
 from substack_analyzer.model import simulate_growth
 from substack_analyzer.persistence import (
@@ -451,8 +458,10 @@ def events_editor(plot_df: pd.DataFrame, target_col: str | None) -> None:
                 else:
                     max_changes = int(st.session_state.get("max_changes_detect", 3))
 
-                    def _detect(series: pd.Series) -> list:
-                        return detect_and_classify(series.dropna(), max_changes=max_changes, window=6)
+                    detect_cfg = DetectionConfig(use_classifier=True, max_changes=max_changes, window=6)
+
+                    def _detect(series: pd.Series) -> DetectionResult:
+                        return run_detection(series, config=detect_cfg)
 
                     # Debug: record detection configuration
                     try:
@@ -485,48 +494,49 @@ def events_editor(plot_df: pd.DataFrame, target_col: str | None) -> None:
                             pass
 
                     # Determine which series to run on
-                    classified_list: list = []
+                    detections: list[DetectionResult] = []
                     label_list: list[str] = []
                     # Auto
                     if detect_mode.startswith("Auto"):
                         s_auto = plot_df[target_col].dropna()
-                        classified_list = [_detect(s_auto)]
+                        detections = [_detect(s_auto)]
                         label_list = [target_col]
-                        _log_classified(label_list[0], classified_list[0])
+                        _log_classified(label_list[0], detections[0].classified)
                     # Explicit targets
                     elif detect_mode == "Total" and ("Total" in plot_df.columns):
-                        classified_list = [_detect(plot_df["Total"])]
+                        detections = [_detect(plot_df["Total"])]
                         label_list = ["Total"]
                         target_col = "Total"
-                        _log_classified("Total", classified_list[0])
+                        _log_classified("Total", detections[0].classified)
                     elif detect_mode == "Free" and ("Free" in plot_df.columns):
-                        classified_list = [_detect(plot_df["Free"])]
+                        detections = [_detect(plot_df["Free"])]
                         label_list = ["Free"]
                         target_col = "Free"
-                        _log_classified("Free", classified_list[0])
+                        _log_classified("Free", detections[0].classified)
                     elif detect_mode == "Paid" and ("Paid" in plot_df.columns):
-                        classified_list = [_detect(plot_df["Paid"])]
+                        detections = [_detect(plot_df["Paid"])]
                         label_list = ["Paid"]
                         target_col = "Paid"
-                        _log_classified("Paid", classified_list[0])
+                        _log_classified("Paid", detections[0].classified)
                     elif detect_mode.startswith("Both") and ({"Total", "Paid"}.issubset(plot_df.columns)):
-                        classified_list = [_detect(plot_df["Total"]), _detect(plot_df["Paid"])]
+                        detections = [_detect(plot_df["Total"]), _detect(plot_df["Paid"])]
                         label_list = ["Total", "Paid"]
-                        _log_classified("Total", classified_list[0])
-                        _log_classified("Paid", classified_list[1])
+                        _log_classified("Total", detections[0].classified)
+                        _log_classified("Paid", detections[1].classified)
                     else:
                         st.info("Requested detection target not available in current data.")
-                        classified_list = []
+                        detections = []
 
                     # Merge results
                     merged_events_df = None
-                    merged_classified = []
+                    merged_classified: list[BreakpointEffect] = []
 
-                    if not classified_list or all(len(c) == 0 for c in classified_list):
+                    if not detections or all(len(res.classified) == 0 for res in detections):
                         st.info("No change dates detected with current settings.")
                     else:
                         # Seed events per source label
-                        for cls, label in zip(classified_list, label_list):
+                        for result, label in zip(detections, label_list):
+                            cls = result.classified
                             if not cls:
                                 continue
                             seeded_df = breakpoints_to_events(cls, target_label=label)
@@ -583,11 +593,11 @@ def events_editor(plot_df: pd.DataFrame, target_col: str | None) -> None:
                                         merged.append(d)
                             return merged
 
-                        seg_effects = [
-                            b
-                            for b in merged_classified
-                            if (b.effect == "Persistent" and b.component in {"rate", "mixed"})
-                        ]
+                        seg_effects = filter_breakpoints(
+                            merged_classified,
+                            effects=["Persistent"],
+                            components=["rate", "mixed"],
+                        )
                         try:
                             logger.info(
                                 "Classifier filtered (Persistent & rate/mixed): %s",

--- a/scripts/run_headless.py
+++ b/scripts/run_headless.py
@@ -35,7 +35,12 @@ from substack_analyzer.analysis import (
     read_series,
 )
 from substack_analyzer.calibration import fit_piecewise_logistic
-from substack_analyzer.detection import detect_change_points
+from substack_analyzer.changepoints import (
+    DetectionConfig,
+    DetectionResult,
+    filter_breakpoints,
+    run_detection,
+)
 from substack_analyzer.persistence import export_phase_one_json
 from substack_analyzer.utils import ensure_month_end_index
 
@@ -60,6 +65,14 @@ class PhaseOneConfig:
     lam: float
     theta: float
     out_dir: str
+    detector: str
+    min_seg_len: int
+    penalty_scale: float
+    window: int
+    z_pulse: float
+    rate_factor: float
+    level_factor: float
+    filter_persistent: bool
 
 
 def run_from_phase_one_config(cfg: PhaseOneConfig) -> None:
@@ -79,6 +92,14 @@ def run_from_phase_one_config(cfg: PhaseOneConfig) -> None:
         lam=cfg.lam,
         theta=cfg.theta,
         out_dir=cfg.out_dir,
+        detector=cfg.detector,
+        min_seg_len=cfg.min_seg_len,
+        penalty_scale=cfg.penalty_scale,
+        window=cfg.window,
+        z_pulse=cfg.z_pulse,
+        rate_factor=cfg.rate_factor,
+        level_factor=cfg.level_factor,
+        filter_persistent=cfg.filter_persistent,
     )
 
 
@@ -130,6 +151,15 @@ def run(
     lam: float,
     theta: float,
     out_dir: str,
+    *,
+    detector: str,
+    min_seg_len: int,
+    penalty_scale: float,
+    window: int,
+    z_pulse: float,
+    rate_factor: float,
+    level_factor: float,
+    filter_persistent: bool,
 ) -> None:
     os.makedirs(out_dir, exist_ok=True)
     logger.info("Starting headless run")
@@ -208,8 +238,45 @@ def run(
 
     # Detection target selection and optional merge
 
-    def _detect_indices(series: pd.Series) -> list[int]:
-        return detect_change_points(series.dropna(), max_changes=max_changes, min_seg_len=3, return_mode="indices")
+    detection_cfg = DetectionConfig(
+        use_classifier=(detector == "classifier"),
+        max_changes=max_changes,
+        min_seg_len=min_seg_len,
+        penalty_scale=penalty_scale,
+        window=window,
+        z_pulse=z_pulse,
+        rate_factor=rate_factor,
+        level_factor=level_factor,
+    )
+
+    logger.debug(
+        "Detector cfg: detector=%s, max_changes=%d, min_seg_len=%d, penalty_scale=%.2f, window=%d, filter_persistent=%s",
+        detector,
+        max_changes,
+        min_seg_len,
+        penalty_scale,
+        window,
+        filter_persistent,
+    )
+
+    detection_results: dict[str, DetectionResult] = {}
+
+    def _detect(series: pd.Series, label: str) -> DetectionResult:
+        res = run_detection(series, config=detection_cfg)
+        detection_results[label] = res
+        return res
+
+    def _filtered_indices(result: DetectionResult, filter_segments: bool) -> list[int]:
+        if not result.indices:
+            return []
+        if detection_cfg.use_classifier and filter_segments:
+            filtered = filter_breakpoints(
+                result.classified,
+                effects=["Persistent"],
+                components=["rate", "mixed"],
+            )
+            return sorted({int(b.index) for b in filtered})
+        return result.indices
 
     def _indices_to_dates(series: pd.Series, indices: list[int]) -> list[pd.Timestamp]:
         s_idx = series.dropna().index
@@ -244,27 +311,33 @@ def run(
         )
         if target is None:
             raise SystemExit("No suitable series for detection (Auto mode)")
-        bkps = _detect_indices(target)
+        det = _detect(target, label="auto")
+        bkps = _filtered_indices(det, filter_persistent)
     elif detect_mode == "total":
         if "Total" not in plot_df.columns:
             raise SystemExit("Total series not available for detection")
-        bkps = _detect_indices(plot_df["Total"])
+        det = _detect(plot_df["Total"], label="Total")
+        bkps = _filtered_indices(det, filter_persistent)
         fit_series = plot_df["Total"]
     elif detect_mode == "paid":
         if "Paid" not in plot_df.columns:
             raise SystemExit("Paid series not available for detection")
-        bkps = _detect_indices(plot_df["Paid"])
+        det = _detect(plot_df["Paid"], label="Paid")
+        bkps = _filtered_indices(det, filter_persistent)
         fit_series = plot_df["Paid"]
     elif detect_mode == "free":
         if "Free" not in plot_df.columns:
             raise SystemExit("Free series not available for detection (need Total and Paid)")
-        bkps = _detect_indices(plot_df["Free"])
+        det = _detect(plot_df["Free"], label="Free")
+        bkps = _filtered_indices(det, filter_persistent)
         # Fit preference stays: Total if present else Paid else Free
     elif detect_mode == "both":
         if not {"Total", "Paid"}.issubset(plot_df.columns):
             raise SystemExit("Both mode requires Total and Paid series")
-        b_total = _detect_indices(plot_df["Total"])
-        b_paid = _detect_indices(plot_df["Paid"])
+        det_total = _detect(plot_df["Total"], label="Total")
+        det_paid = _detect(plot_df["Paid"], label="Paid")
+        b_total = _filtered_indices(det_total, filter_persistent)
+        b_paid = _filtered_indices(det_paid, filter_persistent)
         d_total = _indices_to_dates(plot_df["Total"], b_total)
         d_paid = _indices_to_dates(plot_df["Paid"], b_paid)
         d_merged = _merge_dates(d_total + d_paid, min_gap_months=1)
@@ -274,7 +347,12 @@ def run(
         bkps = sorted(set(bkps))
     else:
         raise SystemExit(f"Unknown detect-on mode: {detect_mode}")
-    logger.info("Detection mode=%s, breakpoints=%s", detect_mode, bkps)
+    logger.info(
+        "Detection mode=%s, detector=%s, breakpoints=%s",
+        detect_mode,
+        detector,
+        bkps,
+    )
 
     # Features and optional ad spend (use configured lam/theta)
     ad_file_handle = _open_file(adspend_path) if adspend_path else None
@@ -299,6 +377,10 @@ def run(
     st.session_state["adstock_lambda"] = float(lam_best)
     st.session_state["ad_log_theta"] = float(theta_best)
     st.session_state["detected_breakpoints"] = bkps
+    if detection_results:
+        st.session_state["detected_classified"] = {
+            label: res.classified for label, res in detection_results.items() if res.classified
+        }
     # Map indices to dates based on chosen fit_series base
     try:
         s_idx = fit_series.dropna().index
@@ -336,6 +418,11 @@ def run(
     out_summary = {
         "breakpoints": bkps,
         "detect_on": detect_mode,
+        "detector": detector,
+        "filter_persistent": filter_persistent,
+        "min_seg_len": min_seg_len,
+        "penalty_scale": penalty_scale,
+        "window": window,
         "breakpoints_total": (b_total if 'b_total' in locals() else None),
         "breakpoints_paid": (b_paid if 'b_paid' in locals() else None),
         "carrying_capacity": fit.carrying_capacity,
@@ -466,6 +553,29 @@ def main() -> None:
         choices=["auto", "total", "paid", "free", "both"],
         help="Which series to detect change points on (and merge if both)",
     )
+    p.add_argument(
+        "--detector",
+        type=str,
+        default="classifier",
+        choices=["classifier", "simple"],
+        help="Change-point detector to use (classifier matches Streamlit app)",
+    )
+    p.add_argument("--min-seg-len", type=int, default=2, help="Minimum segment length for detector")
+    p.add_argument(
+        "--penalty-scale",
+        type=float,
+        default=4.0,
+        help="Penalty scale for detector (larger → fewer change points)",
+    )
+    p.add_argument("--window", type=int, default=6, help="Classifier window (months) for slopes/levels")
+    p.add_argument("--z-pulse", type=float, default=3.0, help="Z threshold for transient pulses")
+    p.add_argument("--rate-factor", type=float, default=0.75, help="Rate sensitivity multiplier")
+    p.add_argument("--level-factor", type=float, default=0.75, help="Level sensitivity multiplier")
+    p.add_argument(
+        "--keep-all-breaks",
+        action="store_true",
+        help="When using the classifier, keep all detected breakpoints (skip persistent rate/mixed filter)",
+    )
     p.add_argument("--lam", type=float, default=0.5, help="Adstock lambda carryover [0,1)")
     p.add_argument("--theta", type=float, default=500.0, help="Ad effect log scale")
     p.add_argument("--out-dir", type=str, default="./outputs", help="Output directory")
@@ -488,6 +598,14 @@ def main() -> None:
         lam=args.lam,
         theta=args.theta,
         out_dir=args.out_dir,
+        detector=args.detector,
+        min_seg_len=args.min_seg_len,
+        penalty_scale=args.penalty_scale,
+        window=args.window,
+        z_pulse=args.z_pulse,
+        rate_factor=args.rate_factor,
+        level_factor=args.level_factor,
+        filter_persistent=not args.keep_all_breaks,
     )
     run_from_phase_one_config(cfg)
 

--- a/substack_analyzer/changepoints.py
+++ b/substack_analyzer/changepoints.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Literal, Optional
+from typing import Iterable, List, Literal, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,28 @@ class BreakpointEffect:
     rate_score: float  # |Δslope| relative to rate threshold
     level_score: float  # |Δlevel| relative to level threshold
     note: str | None = None
+
+
+@dataclass(frozen=True)
+class DetectionConfig:
+    """Shared configuration for change-point detection across app + headless runs."""
+
+    use_classifier: bool = True
+    max_changes: int = 4
+    min_seg_len: int = 2
+    penalty_scale: float = 4.0
+    window: int = 6
+    z_pulse: float = 3.0
+    rate_factor: float = 0.75
+    level_factor: float = 0.75
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    """Container for the outputs of ``run_detection``."""
+
+    indices: list[int]
+    classified: list[BreakpointEffect]
 
 
 def _mad(x: np.ndarray) -> float:
@@ -177,6 +199,68 @@ def breakpoints_for_segments(bps: List[BreakpointEffect]) -> List[int]:
         return False
 
     return sorted(set(b.index for b in bps if is_segment_worthy(b)))
+
+
+def filter_breakpoints(
+    bps: Sequence[BreakpointEffect],
+    *,
+    effects: Iterable[Effect] | None = None,
+    components: Iterable[Component] | None = None,
+) -> list[BreakpointEffect]:
+    """Return a filtered list of ``BreakpointEffect`` objects matching the criteria."""
+
+    eff_set = {e for e in (effects or [])}
+    comp_set = {c for c in (components or [])}
+
+    def _matches(b: BreakpointEffect) -> bool:
+        eff_ok = True if not eff_set else b.effect in eff_set
+        comp_ok = True if not comp_set else b.component in comp_set
+        return eff_ok and comp_ok
+
+    return [b for b in bps if _matches(b)]
+
+
+def run_detection(input_series: pd.Series, config: DetectionConfig | None = None) -> DetectionResult:
+    """Run change-point detection with shared configuration.
+
+    Parameters
+    ----------
+    input_series:
+        Series to analyse (will be ``dropna``/``sort_index`` cleaned).
+    config:
+        Optional :class:`DetectionConfig`. When omitted the defaults mirror the
+        interactive app (classifier-based detector with a six-month window).
+    """
+
+    cfg = config or DetectionConfig()
+    series = input_series.dropna().sort_index()
+    if series.empty:
+        return DetectionResult(indices=[], classified=[])
+
+    if cfg.use_classifier:
+        classified = detect_and_classify(
+            series,
+            max_changes=cfg.max_changes,
+            min_seg_len=cfg.min_seg_len,
+            penalty_scale=cfg.penalty_scale,
+            window=cfg.window,
+            z_pulse=cfg.z_pulse,
+            rate_factor=cfg.rate_factor,
+            level_factor=cfg.level_factor,
+        )
+        indices = sorted({int(b.index) for b in classified})
+        return DetectionResult(indices=indices, classified=classified)
+
+    indices = list(
+        detect_change_points(
+            series,
+            max_changes=cfg.max_changes,
+            min_seg_len=cfg.min_seg_len,
+            penalty_scale=cfg.penalty_scale,
+            return_mode="indices",
+        )
+    )
+    return DetectionResult(indices=sorted({int(i) for i in indices}), classified=[])
 
 
 def detect_and_classify(

--- a/tests/test_changepoints.py
+++ b/tests/test_changepoints.py
@@ -1,7 +1,13 @@
 import pandas as pd
 
 from substack_analyzer.calibration import fit_piecewise_logistic
-from substack_analyzer.changepoints import breakpoints_for_segments, breakpoints_to_events, detect_and_classify
+from substack_analyzer.changepoints import (
+    DetectionConfig,
+    breakpoints_for_segments,
+    breakpoints_to_events,
+    detect_and_classify,
+    run_detection,
+)
 from substack_analyzer.detection import detect_change_points
 
 
@@ -98,3 +104,28 @@ def test_detect_change_points_smoke():
     s = pd.Series([100, 105, 110, 115, 120, 125, 150, 155, 160, 165, 170, 175], index=idx)
     bkps = detect_change_points(s, max_changes=3, return_mode="indices")
     assert isinstance(bkps, list)
+
+
+def test_run_detection_matches_helpers():
+    idx = pd.period_range("2021-01", periods=18, freq="M").to_timestamp("M")
+    s = pd.Series(
+        [100, 101, 103, 104, 150, 151, 152, 160, 162, 164, 166, 210, 212, 214, 216, 218, 220, 222],
+        index=idx,
+    )
+
+    cfg = DetectionConfig(use_classifier=True, max_changes=4, window=4)
+    result = run_detection(s, config=cfg)
+    expected_classified = detect_and_classify(s, max_changes=4, window=4)
+    assert result.classified == expected_classified
+    assert result.indices == sorted({b.index for b in expected_classified})
+
+    simple_cfg = DetectionConfig(use_classifier=False, max_changes=4, min_seg_len=3)
+    simple_result = run_detection(s, config=simple_cfg)
+    expected_indices = detect_change_points(
+        s,
+        max_changes=4,
+        min_seg_len=3,
+        return_mode="indices",
+    )
+    assert simple_result.classified == []
+    assert simple_result.indices == sorted(expected_indices)


### PR DESCRIPTION
## Summary
- add shared detection configuration helpers so both the Streamlit app and headless runner invoke the same change-point pipeline
- switch the app’s change detection to the shared helper while preserving classifier filtering used for segment selection
- update the headless runner to support the shared pipeline, expose detector configuration flags, and persist classifier metadata
- cover the shared helper with regression tests validating both classifier and simple modes

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ae5623a083279f98a5b5746b0b19)