### PR TITLE
Remove outdated modeling stages UI copy

### DIFF
--- a/app.py
+++ b/app.py
@@ -1956,13 +1956,12 @@ render_brand_header()
 
 # Tabs
 with st.container():
-    tab_import, tab_sim, tab_est, tab_save, tab_stages, tab_help = st.tabs(
+    tab_import, tab_sim, tab_est, tab_save, tab_help = st.tabs(
         [
             "Data Import",
             "Simulator",
             "Estimators",
             "Save / Load",
-            "Stages",
             "Help",
         ]
     )
@@ -2049,7 +2048,7 @@ with tab_sim:
         nxt = [
             "- Set assumptions in the sidebar: growth, churn, conversion, pricing, CAC, ad spend.",
             "- Run the Simulator below to project subscribers, revenue, ROAS, and payback.",
-            "- Optional: use the model fit to calibrate growth dynamics; advanced Bayesian fit coming soon.",
+            "- Optional: use the model fit to calibrate growth dynamics from the Estimators tab.",
         ]
         st.markdown("\n".join(nxt))
     with st.expander("Save / Load (quick access)", expanded=False):
@@ -2087,23 +2086,6 @@ with tab_est:
 
 with tab_save:
     render_save_load()
-
-with tab_stages:
-    st.subheader("Modeling Stages")
-    st.markdown(
-        """
-1. **File Upload & Parsing**: Upload All/Paid exports. Outputs `observations_df` (daily preferred) with imputation flags; quick charts.
-2. **Events & Covariates**: Add shoutouts/ads; adstock + diminishing returns; seasonality features. Outputs `events_df`, `covariates_df`, `features_df`.
-3. **Adds/Churn Prep**: From logs (preferred) or totals-only via smoothing; tenure-based churn hazard. Outputs `adds_df`, `churn_df`.
-4. **Model Fitting (Pro)**: Bayesian state-space with saturation, events, and uncertainty. Outputs `bayes_fit`, fit plots.
-5. **Diagnostics**: Rolling-origin CV, PPC, PSIS-LOO; attribution and elasticity checks. Outputs `validation_report`.
-6. **Forecasting & Scenarios**: Posterior simulation under levers (events, ads, cadence, market). Outputs `forecast_df`.
-7. **Cohort & Finance Simulator**: Monthly KPIs, ROAS, CAC, payback. Outputs `sim_df`.
-8. **Outputs & Docs**: Formulas and downloadable artifacts.
-
-Status: Stages 1–3 (import, events, quick estimators) and Model fit are implemented. Pro Fit (Bayesian), diagnostics, and scenario planner are in progress.
-        """
-    )
 
 with tab_help:
     render_help()


### PR DESCRIPTION
## Summary
- remove the Modeling Stages tab that advertised unshipped features
- refresh the simulator guidance to avoid promising unbuilt features

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691419aa80f08327b10d3a8622102619)