### PR TITLE
Remove planned Bayesian scenario references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,332 +1,160 @@
-# Substack Growth Modeling — System Design (State‑Space/Bayesian)
+# Substack Growth Modeling — System Design
 
 [IN PROGRESS]
 
-This updates the original design to a structural, _adds–churn_ model with saturation, interventions (shoutouts/ads), and explicit uncertainty via a Bayesian state‑space approach. It supports realistic phases (slow start → spikes → paid acquisition → saturation), scenario planning, and calibrated forecasts.
+This document captures the shipping scope of the Substack growth analysis tool. The
+current product centers on a deterministic pipeline: clean the Substack exports,
+annotate events, derive heuristic adds/churn estimates, fit a piecewise logistic
+model, and feed those results into a cohort simulator with export tooling. Longer-
+term ideas still exist, but anything not listed here should be treated as out of
+scope.
 
 ---
 
-## What’s Different vs Original
+## What’s Included Today
 
-- **Adds vs. churn** modeled separately (better attribution + forecasting) instead of net-only deltas.
-- **Saturation** via time‑varying carrying capacity $K_t$ and growth rate $r_t$ with **change‑points** or random walks, replacing fixed piecewise logistic.
-- **Events** split into **pulse** (short‑lived bursts) and **step** (ongoing lift), plus **adstock with diminishing returns** for ads.
-- **Bayesian estimation** with predictive intervals and time‑series cross‑validation, not just OLS on deltas.
-- **Scenario engine** operates on posterior draws (uncertainty propagates), not just deterministic extrapolation.
+- **Adds vs. churn separation** derived from totals using heuristic rates.
+- **Piecewise logistic fit** with change-points sourced from the detection module.
+- **Events and adstock features** that flow consistently from import → fit → simulator.
+- **Deterministic cohort simulator** with finance metrics and export bundles.
+- **Manual and automated exports** for handoffs between phases.
 
 ---
 
-## Stage 1 — File Upload & Parsing (Daily Preferred)
+## Phase 1 — Fit & Diagnostics
+
+### Stage 1 — File Upload & Parsing
 
 **Inputs**
 
-- Substack exports:
-
-  - _All subscribers_ (CSV/XLSX): date, total subscribers (cumulative active).
-  - _Paid subscribers_ (CSV/XLSX): date, paid active subscribers.
-  - _(Optional, if available)_ subscriber event logs: signups/cancels by date.
-
-- _(Optional)_ External tables: ad spend (by channel), shoutouts (date, size), posts sent, social metrics, Google Trends.
-- User options: header flags, column indices, time zone.
+- Substack _All Subscribers_ export (CSV/XLSX).
+- Substack _Paid Subscribers_ export (CSV/XLSX).
+- Optional starter bundles (`phase1.json`) captured by earlier sessions.
 
 **Processing**
 
-- Read and coerce dates; drop invalid; sort ascending.
-- Normalize to **daily index** (preferred). If input is sparser (weekly/monthly), resample to daily using last observation carry‑forward; tag imputed days.
-- Derive `Free = Total − Paid` (clip at ≥0).
-- Build a canonical **observations table** with columns below (see Data Contracts).
+- Load the files with flexible column selection.
+- Normalize to month-end cadence with explicit imputation flags.
+- Derive Free = Total − Paid, clipped at zero.
 
 **Outputs**
 
-- `observations_df` (daily): `date`, `active_total`, `active_paid`, `active_free`, with flags for imputation.
-- Quick plots: active series (free/paid/total), daily/weekly net changes.
+- `observations_df`: monthly totals (paid, free, total) + metadata.
+- Download link for the cleaned table.
 
 ---
 
-## Stage 2 — Event & Covariate Capture
+### Stage 2 — Events & Features
 
 **Inputs**
 
-- User‑labeled events: `date`, `type` (Ad, Shoutout, Press, Other), `notes`, `size` (audience/spend), `channel`, `cost`.
-- _(Optional)_ Auto‑detected change‑points suggest candidate dates.
-- External covariates: ad spend/impressions by channel, posts sent, social mentions, search interest.
+- Manual event table captured in the UI (`events_df`).
+- Suggested change-points from the detection helper.
+- Sidebar inputs for adstock λ and log-response θ.
 
 **Processing**
 
-- Normalize all events/covariates to **daily**.
-- Compute **adstock** per channel: $a_t = x_t + \lambda a_{t-1}$, $\lambda\in[0,1)$ learned.
-- Define **diminishing returns** transform for ads:
-
-  - Log: $g(a_t) = \beta\, \log(1 + a_t/\theta)$
-
-- Encode **shoutouts** as:
-
-  - **Pulse** features (short‑lived): Dirac at date convolved with short decay kernel (1–7 days).
-  - **Step** features (level lift): indicator $\mathbf{1}(t\ge d)$.
-
-- Pulse kernel parameterization: specify half‑life $h$ so that the decay factor $\lambda = 0.5^{1/h}$. Start with a fixed $h$ (e.g., 3 days) and later allow learning $h$ hierarchically across shoutouts.
-- Step effects: estimate per‑event step sizes with partial pooling (hierarchical prior) to stabilize small events.
+- Normalize event types and persistence (Transient, Persistent, None).
+- Build adstocked spend series and log-response features.
+- Emit combined feature sets for later modules (`covariates_df`, `features_df`).
 
 **Outputs**
 
-- `events_df` (daily): pulse/step encodings with metadata.
-- `covariates_df` (daily): ad spend by channel, posts, social, search.
-- `features_df` (daily): adstocked series, transformed ad response, content cadence.
+- Editable events grid with import/export of `phase1.json`.
+- Downloadable CSVs of engineered features.
 
 ---
 
-## Stage 3 — Adds/Churn Preparation
+### Stage 3 — Adds & Churn
+
+**Processing**
+
+- Apply heuristic churn estimates supplied in the sidebar.
+- Split net deltas into `adds_df` and `churn_df` tables.
+- Provide CSV downloads for validation outside the app.
+
+---
+
+### Stage 4 — Quick Fit
+
+**Processing**
+
+- Run change-point detection to segment the piecewise logistic.
+- Fit capacity, growth, and event coefficients with optional ad-response term.
+- Surface override sliders for manual adjustments.
+
+**Outputs**
+
+- Fitted parameters, overlay charts, and forward projections.
+- Growth equation text block for downstream reference.
+
+---
+
+### Stage 5 — Diagnostics
+
+**Processing**
+
+- Show delta charts with slope overlays and trailing-window metrics.
+- Highlight quick estimators (growth rates, implied churn, saturation proximity).
+
+**Outputs**
+
+- Status recap for Stage 1–4 artifacts.
+- Download of the assembled `phase1.json` bundle.
+
+_Future work:_ richer cross-validation beyond the current summary checks.
+
+---
+
+## Phase 2 — Simulation & Outputs
+
+### Stage 6 — Cohort & Finance Simulator
 
 **Inputs**
 
-- `observations_df` (+ optionally subscriber event logs), `features_df`.
+- `phase1.json` or a full session bundle from Phase 1.
+- Scenario levers: growth modifiers, churn overrides, ad spend schedules, conversion settings.
 
 **Processing**
 
-- **Path A (preferred)**: If signup/cancel logs exist, aggregate to daily `gross_adds_*` and `cancels_*` (free/paid).
-- **Path B (totals only)**: Use a **Kalman smoother** (structural time‑series) to decompose net changes into latent `gross_adds` and `cancels`, with:
-
-  - Smoothness priors on adds.
-  - A **tenure‑based hazard prior** for churn (declining with age), modulated by content cadence. Enforce monotonicity of the age‑hazard spline or use a decreasing basis to avoid pathological shapes. When only totals exist, anchor paid churn with observed paid data and share information to free churn via a prior relationship.
+- Run deterministic free/paid cohort evolution with tenure-based churn curves.
+- Model free→paid conversion and ad-driven acquisition using Phase 1 estimates.
+- Compute finance KPIs (MRR/ARR, ROAS, CAC, payback).
 
 **Outputs**
 
-- `adds_df` (daily): `gross_adds_free`, `gross_adds_paid` (with uncertainty if latent).
-- `churn_df` (daily): `cancels_free`, `cancels_paid` (with uncertainty if latent).
+- Scenario tables and charts rendered inside Streamlit.
+- KPI tiles summarizing cohort health and financial outcomes.
 
 ---
 
-## Stage 4 — Model Fitting (Bayesian State‑Space with Saturation & Interventions)
-
-**Model sketch (free/total shown; paid can be layered)**
-
-- State (actives): $S_t$.
-- **Growth dynamic with saturation**:
-  $(\Delta S_t = r_t\, S_{t-1}\bigl(1 - S_{t-1}/K_t\bigr) + u_t - \text{churn}_t + \varepsilon_t)$.
-- **Time‑varying parameters**:
-
-  - $r_t$: piecewise‑constant with **unknown change‑points** (0–3) _or_ random walk.
-  - $K_t$: random walk on log‑scale; weakly‑informative upper prior (market size proxy).
-
-- **Exogenous input**: $u_t = \gamma_\text{pulse}\,\text{pulse}_t + \gamma_\text{step}\,\text{step}_t + f_\text{ads}(a_t) + \beta' x_t$.
-
-  - **Adstock**: $a_t = x_t + \lambda a_{t-1}$, $\lambda\in[0,1)$ per channel or shared.
-  - **Diminishing returns**: $f_\text{ads}$ via log form above.
-  - **Other covariates**: content cadence, social/search.
-
-- **Likelihoods** (choose by data availability):
-
-  - If adds/cancels available:
-
-    - `gross_adds_t` $\sim$ NegBin($\mu_{\text{adds},t}$, $\phi_{\text{adds}}$).
-    - `cancels_t` $\sim$ Binomial$(S_{t-1}, \pi_t)$ with $\text{logit}(\pi_t) = \alpha_0 + \alpha' z_t$.
-
-  - If only totals: observation equation $S^{\text{obs}}_t \sim \mathcal{N}(S_t, \sigma_{\text{obs}})$ plus robust noise for outliers.
-
-- **Priors**: weakly informative for $r_t$, $K_t$; half‑normal for positive scales; sparsity prior on # of change‑points; $\lambda\in[0,1)$ uniform or Beta.
-- **Inference**: PyMC/Stan (NUTS). Store posterior draws for all states/parameters.
-
-**Identifiability guardrails**
-
-- Distinguish market size drifts ($K_t$) from permanent level shifts (step events):
-  - Use a small random‑walk variance on $(\log K_t)$ and a spike–slab (or strong sparsity) prior on step coefficients.
-  - Penalize frequent change‑points on $(r_t)$ to avoid overfitting pulses as trend breaks.
-- Ad response: start with a log form $(f_\text{ads}(a_t) = \beta\, \log(1 + a_t/\theta))$; fix $(\eta=1)$ initially for identifiability. Place $(\lambda\sim\text{Beta}(2,2))$ and share $(\theta)$ across sparse channels with hierarchical pooling.
-- Constrain churn hazards to $[0,1]$ and enforce non‑negativity on adds; clip forecasts at capacity draws (see Scenario Constraints).
-
-**Inputs**
-
-- `observations_df`, `adds_df`, `churn_df`, `features_df`, optional change‑point suggestions.
-
-**Outputs**
-
-- `bayes_fit` object: posterior samples (`S_t`, `K_t`, `r_t`, change‑points, event coefficients, adstock λ, ad elasticity, churn params, dispersion), posterior predictive, log‑likelihood.
-- Fit plots: Actual vs posterior median with 50/80/95% bands; contribution (shap‑like) breakdown for u_t components.
-
----
-
-## Stage 5 — Diagnostics & Validation
+### Stage 7 — Outputs & Documentation
 
 **Processing**
 
-- **Rolling‑origin time‑series CV** (e.g., 4–8 weekly folds). Refit/train on past, forecast next horizon.
-- **Metrics**: MAPE on gross adds, RMSE on actives, coverage for 50/80/95% intervals, CRPS.
-- **Checks**: Prior and posterior predictive checks; PSIS‑LOO or WAIC for model comparison; target interval coverage (e.g., 50%/80%/95%) and well‑behaved residual autocorrelation.
-- **Event attribution checks**: estimated pulse half‑life; step permanence.
-- **Elasticity checks**: slope of $f_\text{ads}$ at current spend; saturation level proximity ($S_t/K_t$).
-- Residual diagnostics: autocorrelation.
+- Export `phase1.json`, simulator CSVs, and zipped session bundles.
+- Surface equation snippets and definitions for the deterministic pipeline.
 
 **Outputs**
 
-- `validation_report`: fold metrics + calibration plots.
-- `attribution_summary`: lifts by event/ad channel with uncertainty.
+- Downloadable artifacts for further analysis or reporting.
+- Lightweight reference documentation embedded in the UI.
+
+_Future work:_ richer automated documentation built from session artifacts.
 
 ---
 
-## Stage 6 — Forecasting & Scenario Planning
+## Data Contracts (Current)
 
-**Inputs**
-
-- `bayes_fit` posterior draws; scenario knobs (future events, ad schedules, cadence changes, market expansion).
-
-**Processing**
-
-- **Posterior simulation**: for each draw, simulate forward `S_t`, `adds`, `cancels` under scenario.
-- Scenario levers:
-
-  - **Shoutouts**: date, pulse size, step proportion, assumed decay.
-  - **Ads**: spend by channel; channel‑specific adstock/response.
-  - **Cadence**: posts/week; impact via $r_t$ or an explicit covariate.
-  - **Market expansion**: exogenous shift in $K_t$ level.
-  - **Pricing/Paywall**: feeds churn and free→paid conversion.
-
-**Outputs**
-
-- `forecast_df`: median and intervals (50/80/95%) for actives, adds, cancels.
-- Scenario comparisons: side‑by‑side KPIs; fan charts.
-
-**Constraints**
-
-- Clip simulated actives by each draw’s $(K_t)$ path; prevent negative adds/churn.
-- Report the share of draws approaching capacity (e.g., $(S_t/K_t > 0.9)$) to flag saturation risk.
-- Bound ad elasticities to reasonable ranges in scenarios to avoid implausible lifts.
+- `observations_df`: `date`, `active_total`, `active_paid`, `active_free`, `is_imputed`.
+- `events_df`: `date`, `type`, `persistence`, `notes`, `cost`.
+- `features_df`: `date`, `adstock`, `ad_effect`, `pulse`, plus derived covariates.
+- `adds_df` / `churn_df`: monthly adds and cancels derived from totals.
+- `simulator_inputs`: serialized configuration for the cohort model.
 
 ---
 
-## Stage 7 — Cohort & Finance Simulator (Paid/Free)
+## Out of Scope
 
-**Inputs**
-
-- Starting states (from `bayes_fit` last day), pricing & fees, CAC and ad schedules, conversion assumptions.
-
-**Processing**
-
-- **Cohort survival**: tenure‑based hazard for churn (age spline + price/cadence flags).
-- **Free→Paid conversion**: function of cadence/exposure and promotions; can be hierarchical if multiple publications.
-- **Revenue**: monthly & annual pricing, Substack/Stripe fees, annual amortization; ROAS, CAC, payback.
-
-**Outputs**
-
-- `sim_df`: monthly KPIs (subs, adds, churn, MRR/ARR, ROAS, CAC, payback month), charts and tiles.
-
----
-
-## Stage 8 — Outputs & Documentation
-
-**Processing**
-
-- Render formulas and definitions for each module.
-- Persist run configs and random seeds for reproducibility.
-
-**Outputs**
-
-- Markdown/HTML reference; downloadable CSVs for fitted states and forecasts; serialized `bayes_fit`.
-
----
-
-## Data Contracts
-
-### `observations_df` (daily)
-
-- `date` (date, unique, sorted)
-- `active_total` (int ≥0)
-- `active_paid` (int ≥0, optional)
-- `active_free` (int ≥0, derived if needed)
-- `is_imputed` (bool) — resampled day indicator
-
-### `events_df` (daily)
-
-- `date` (date)
-- `type` (str: Ad, Shoutout, Press, Other)
-- `channel` (str, optional)
-- `pulse_raw` (float) — raw size (e.g., est. audience)
-- `pulse` (float) — convolved pulse feature
-- `step` (int {0,1}) — step indicator from date onward
-- `cost` (float, optional)
-- `notes` (str)
-
-### `covariates_df` (daily)
-
-- `date`
-- `ad_spend_<channel>` (float ≥0)
-- `posts_sent` (int ≥0)
-- `social_mentions` (int ≥0, optional)
-- `search_index` (float ≥0, optional)
-
-### `features_df` (daily)
-
-- `date`
-- `adstock_<channel>` (float ≥0)
-- `ad_effect_<channel>` (float) — transformed via log
-- `cadence` (float) — posts/week
-
-### `adds_df` (daily)
-
-- `date`
-- `gross_adds_free` (int ≥0)
-- `gross_adds_paid` (int ≥0, optional)
-- `adds_ci_low`, `adds_ci_high` (if latent)
-
-### `churn_df` (daily)
-
-- `date`
-- `cancels_free` (int ≥0)
-- `cancels_paid` (int ≥0, optional)
-- `churn_ci_low`, `churn_ci_high` (if latent)
-
-### `bayes_fit`
-
-- Posterior draws for: `S_t`, `K_t`, `r_t`, change‑point locations, `gamma_pulse`, `gamma_step`, `lambda_adstock`, `beta_ads`, `beta_covariates`, churn parameters, dispersion params.
-- Posterior predictive distributions for observed targets.
-- Log‑likelihood per time point (for PSIS‑LOO).
-
-### `validation_report`
-
-- Fold‑level metrics table; coverage charts; residual diagnostics.
-
-### `forecast_df`
-
-- `date`, median and interval columns for `active_*`, `adds_*`, `cancels_*` under each scenario id.
-
-### `sim_df`
-
-- Monthly aggregates with subscriber/revenue KPIs, ROAS/CAC/payback.
-
----
-
-## Implementation Notes & MVP Path
-
-- **Dependencies**: PyMC or Stan; ArviZ; optional: numpyro.
-- **Computation**: Start with 1–2 change‑points, shared adstock λ across channels (simplify), NegBin for adds.
-- **Runtime & caching**: Target 2–5 minutes per fit (2 chains, ~1k draws post‑warmup). Cache fits keyed by a data hash of inputs/features. If runtime exceeds budget, fall back to Quick Fit (piecewise‑logistic) and offer to enqueue Pro Fit.
-
-**Modes**
-
-- Quick Fit (deterministic): piecewise‑logistic with events (already implemented) for instant overlays and rough forecasts.
-- Pro Fit (Bayesian): full state‑space with uncertainty and scenario simulation.
-
-**MVP order**:
-
-1. Stages 1–2 (ingest + events/covariates) and simple diagnostics.
-2. Stage 3 Path B (latent adds/churn) + quick heuristic estimator for churn if needed.
-3. Stage 4 with single‑segment $r$ + fixed $K$ grid search to sanity‑check.
-4. Swap in full Bayesian with change‑points + $K_t$ drift.
-5. Stage 6 scenarios (ad spend & shoutouts), then Stage 7 finance.
-
-- **Extensibility**:
-
-  - **Bass diffusion** alternative for adds ($p,q,K$) + adstock input.
-  - **Hawkes** option for referrals (self‑exciting adds) bounded by $K_t$.
-  - **Hierarchical** pooling across multiple publications.
-
----
-
-## UI/UX Notes
-
-- Inline event editor with “seed from detected change‑points.”
-- Toggle: _Totals‑only_ vs _Adds/Churn available_; show uncertainty bands when latent.
-- Quick Fit vs Pro Fit toggle with ETA/progress; warn about runtime; cache and allow restoring last fit.
-- Parameter table: medians and 80/95% CrIs for $(r_t)$ levels, $(K_t)$, adstock $(\lambda)$, $(\theta)$, $(\beta)$, and churn hazards.
-- Contribution chart that decomposes forecasted adds into organic (S‑curve), shoutouts (pulse/step), and ads by channel.
-- Scenario panel with reusable templates (e.g., “$2k/mo Meta spend,” “one large shoutout in Q2”).
-- Export buttons for CSV (fitted & forecast), and serialized `bayes_fit` plus compact posterior summaries (JSON).
+Any advanced probabilistic modeling workstreams are tracked separately and should
+not be assumed to exist in the deterministic application described here.

--- a/app.py
+++ b/app.py
@@ -134,7 +134,7 @@ STAGE_PHASES = [
                 "details": [
                     "Shows delta charts plus tail views with segment slope overlays and trailing-window metrics.",
                     "Surfaces quick estimators, supports `phase1.json` download, and applies estimates to the Simulator sidebar.",
-                    "Full cross-validation and posterior diagnostics are still on the roadmap.",
+                    "Full cross-validation remains on the roadmap.",
                 ],
             },
         ],
@@ -142,21 +142,12 @@ STAGE_PHASES = [
     {
         "title": "Phase 2 — Simulation & outputs",
         "summary": (
-            "Stages 6–8 focus on forward planning. Today the app ships with the deterministic"
-            " cohort simulator (Stage 7) plus artifact exports; the posterior scenario engine"
-            " and documentation generator remain planned."
+            "Stages 6–7 focus on forward planning. Today the app ships with the deterministic"
+            " cohort simulator and export tooling, with additional automation still planned."
         ),
         "stages": [
             {
-                "label": "Stage 6 — Posterior scenarios",
-                "status": "⏳ Planned",
-                "details": [
-                    "Will simulate from Bayesian posterior draws once the full state-space fit lands.",
-                    "Targets multi-scenario comparisons with capacity-aware constraints and uncertainty bands.",
-                ],
-            },
-            {
-                "label": "Stage 7 — Cohort & finance simulator",
+                "label": "Stage 6 — Cohort & finance simulator",
                 "status": "✅ Implemented",
                 "details": [
                     "Runs the deterministic free/paid cohort model with growth, churn, conversion, and ad-spend schedules.",
@@ -165,11 +156,11 @@ STAGE_PHASES = [
                 ],
             },
             {
-                "label": "Stage 8 — Outputs & documentation",
+                "label": "Stage 7 — Outputs & documentation",
                 "status": "⚠️ Partial",
                 "details": [
                     "Exports `phase1.json` and full session bundles (.zip) plus CSV downloads for intermediate tables.",
-                    "Auto-generated reference docs and posterior archives are slated for the Bayesian upgrade.",
+                    "Auto-generated reference docs remain on the long-term roadmap.",
                 ],
             },
         ],

--- a/simple_design.md
+++ b/simple_design.md
@@ -74,12 +74,11 @@ Where:
 **Inference options**
 
 - **Quick fit**: grid search over (K, \theta, \lambda); OLS for (r, \beta, \gamma).
-- **Bayesian fit**: priors on parameters; NUTS sampling in PyMC/Stan.
 
 **Outputs**
 
 - Fitted parameters.
-- Posterior predictive bands (if Bayesian).
+- Deterministic projections from the fitted parameters.
 
 ---
 
@@ -104,7 +103,7 @@ Where:
 
 ## Stage 5 — Implementation Notes
 
-- Dependencies: PyMC/Stan, ArviZ, pandas.
+- Dependencies: pandas and scientific Python stack.
 - Start with fixed (\lambda), grid search (K), log-form ads.
 - Weekly aggregation may help runtime.
 


### PR DESCRIPTION
## Summary
- remove the placeholder posterior scenario stage from the Streamlit roadmap copy and renumber the remaining simulation stages
- rewrite the main design document to describe the deterministic pipeline that now ships
- refresh the simplified design note so it no longer promises Bayesian inference or artifacts

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141f41324083279df78878fe2a0050)