### PR TITLE
Fix ad spend session state updates in simulator sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -1344,8 +1344,6 @@ def sidebar_inputs() -> SimulationInputs:
             )
             stage1 = float(stage1 or 0.0)
             stage2 = float(stage2 or 0.0)
-            st.session_state["ad_stage1"] = stage1
-            st.session_state["ad_stage2"] = stage2
             ad_schedule = AdSpendSchedule.two_stage(stage1, stage2)
             st.session_state["spend_mode_index"] = 0
         else:
@@ -1357,7 +1355,6 @@ def sidebar_inputs() -> SimulationInputs:
                 key="ad_const",
             )
             const_spend = float(const_spend or 0.0)
-            st.session_state["ad_const"] = const_spend
             ad_schedule = AdSpendSchedule.constant(const_spend)
             st.session_state["spend_mode_index"] = 1
 


### PR DESCRIPTION
## Summary
- stop mutating Streamlit session state keys tied to ad spend widgets after they are instantiated
- allow Streamlit simulator sidebar to render without session_state mutation errors when loading data

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691422696ac083279b2cb097db4921fa)