### PR TITLE
Handle non-finite growth estimates

### DIFF
--- a/substack_analyzer/analysis.py
+++ b/substack_analyzer/analysis.py
@@ -266,7 +266,7 @@ def compute_estimates(all_series: pd.Series | None, paid_series: pd.Series | Non
         return st.session_state.get(key, default)
 
     def _median_positive(s: pd.Series) -> float:
-        s = s.replace([np.inf, -np.inf], pd.NA).dropna()
+        s = s.replace([np.inf, -np.inf], np.nan).dropna()
         s = s[s > 0]
         return float(s.median()) if not s.empty else 0.0
 

--- a/substack_analyzer/analysis.py
+++ b/substack_analyzer/analysis.py
@@ -3,6 +3,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import IO
 
+import numpy as np
 import altair as alt
 import pandas as pd
 import streamlit as st
@@ -265,7 +266,7 @@ def compute_estimates(all_series: pd.Series | None, paid_series: pd.Series | Non
         return st.session_state.get(key, default)
 
     def _median_positive(s: pd.Series) -> float:
-        s = s.dropna()
+        s = s.replace([np.inf, -np.inf], pd.NA).dropna()
         s = s[s > 0]
         return float(s.median()) if not s.empty else 0.0
 


### PR DESCRIPTION
## Summary
- filter out infinite rate values before computing the median growth estimates
- add numpy dependency import used for sanitising rate series

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142839870483279013354bf802f443)