### PR TITLE
Add logging for model fit parameter rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -1513,7 +1513,7 @@ def sidebar_inputs() -> SimulationInputs:
     with st.sidebar.expander("Model fit parameters", expanded=True):
         fit = st.session_state.get("pwlog_fit")
         if fit is not None:
-            logger.debug(
+            logger.info(
                 "Rendering model fit parameters: carrying_capacity=%s, gamma_pulse=%s, gamma_step=%s, gamma_exog=%s",
                 getattr(fit, "carrying_capacity", None),
                 getattr(fit, "gamma_pulse", None),
@@ -1560,10 +1560,10 @@ def sidebar_inputs() -> SimulationInputs:
 
                 # Segment growth rates r_j
                 base_r_list = coerce_list(st.session_state.get("modelfit_r"))
-                logger.debug("Initial base_r_list from session state: %s", base_r_list)
+                logger.info("Initial base_r_list from session state: %s", base_r_list)
                 if not base_r_list:
                     base_r_list = coerce_list(getattr(fit, "segment_growth_rates", None))
-                    logger.debug("Fallback base_r_list from fit: %s", base_r_list)
+                    logger.info("Fallback base_r_list from fit: %s", base_r_list)
             except Exception:
                 logger.exception("Model fit parameters available, but could not render editor. fit=%s", fit)
                 st.caption("Model fit parameters available, but could not render editor.")

--- a/app.py
+++ b/app.py
@@ -1512,6 +1512,14 @@ def sidebar_inputs() -> SimulationInputs:
     # Model fit parameters (read from fit; allow manual override for what-if scenarios)
     with st.sidebar.expander("Model fit parameters", expanded=True):
         fit = st.session_state.get("pwlog_fit")
+        if fit is not None:
+            logger.debug(
+                "Rendering model fit parameters: carrying_capacity=%s, gamma_pulse=%s, gamma_step=%s, gamma_exog=%s",
+                getattr(fit, "carrying_capacity", None),
+                getattr(fit, "gamma_pulse", None),
+                getattr(fit, "gamma_step", None),
+                getattr(fit, "gamma_exog", None),
+            )
         if fit is None:
             st.caption("No model fit available yet. Run Model fit on the Estimators tab or edit r below for simulations.")
         else:
@@ -1552,9 +1560,12 @@ def sidebar_inputs() -> SimulationInputs:
 
                 # Segment growth rates r_j
                 base_r_list = coerce_list(st.session_state.get("modelfit_r"))
+                logger.debug("Initial base_r_list from session state: %s", base_r_list)
                 if not base_r_list:
                     base_r_list = coerce_list(getattr(fit, "segment_growth_rates", None))
+                    logger.debug("Fallback base_r_list from fit: %s", base_r_list)
             except Exception:
+                logger.exception("Model fit parameters available, but could not render editor. fit=%s", fit)
                 st.caption("Model fit parameters available, but could not render editor.")
                 base_r_list = []
         if fit is None:


### PR DESCRIPTION
## Summary
- add debug logging to capture fit parameter values prior to rendering the sidebar controls
- record the initial and fallback segment growth rate lists pulled from state or fit
- log any exceptions that prevent the model fit parameter editor from rendering

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914399277c88327b9272ff04921a1d7)