### PR TITLE
Add diagnostic logging for last segment growth rate overrides

### DIFF
--- a/app.py
+++ b/app.py
@@ -972,16 +972,29 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
 
             existing_r = coerce_list(st.session_state.get("modelfit_r"))
             if ("modelfit_r" not in st.session_state) or (len(existing_r) != len(fit_r_list)):
+                logger.info(
+                    "Initializing modelfit_r overrides from fit: existing_len=%s, fit_len=%s",
+                    len(existing_r),
+                    len(fit_r_list),
+                )
                 st.session_state["modelfit_r"] = fit_r_list
                 if fit_r_list:
                     last_fit_r = _safe_float(fit_r_list[-1], 0.0)
                     st.session_state["modelfit_r_last_value"] = last_fit_r
                     st.session_state["modelfit_r_last_default"] = last_fit_r
+                    logger.info(
+                        "Clearing last segment widget state after fit init; new default=%s",
+                        last_fit_r,
+                    )
                     st.session_state.pop("modelfit_r_last_input", None)
             elif ("modelfit_r_last_value" not in st.session_state) and existing_r:
                 last_existing_r = _safe_float(existing_r[-1], 0.0)
                 st.session_state["modelfit_r_last_value"] = last_existing_r
                 st.session_state["modelfit_r_last_default"] = last_existing_r
+                logger.info(
+                    "Seeding last segment widget state from existing overrides; default=%s",
+                    last_existing_r,
+                )
                 st.session_state.pop("modelfit_r_last_input", None)
 
             existing_intercepts = coerce_list(st.session_state.get("modelfit_intercepts"))
@@ -1608,7 +1621,35 @@ def sidebar_inputs() -> SimulationInputs:
 
         last_segment_default = float(base_r_list[-1] if base_r_list else organic_default)
         last_default = st.session_state.get("modelfit_r_last_default")
-        if last_default is None or not math.isclose(last_default, last_segment_default, rel_tol=1e-9, abs_tol=1e-9):
+        reset_last_input = False
+        if last_default is None:
+            logger.info(
+                "No stored last segment default; resetting widget state to computed default=%s",
+                last_segment_default,
+            )
+            reset_last_input = True
+        else:
+            defaults_match = math.isclose(
+                last_default,
+                last_segment_default,
+                rel_tol=1e-9,
+                abs_tol=1e-9,
+            )
+            if not defaults_match:
+                logger.info(
+                    "Last segment default drift detected; stored=%s computed=%s abs_diff=%s. Clearing widget state.",
+                    last_default,
+                    last_segment_default,
+                    abs(last_default - last_segment_default),
+                )
+                reset_last_input = True
+            else:
+                logger.debug(
+                    "Last segment default %s matches computed %s within tolerance; preserving widget state.",
+                    last_default,
+                    last_segment_default,
+                )
+        if reset_last_input:
             st.session_state["modelfit_r_last_default"] = last_segment_default
             st.session_state.pop("modelfit_r_last_input", None)
         last_r_val = number_input_state(


### PR DESCRIPTION
## Summary
- add logging when initializing growth rate overrides from a new fit or existing session values
- log explicit reasons when the last segment growth rate widget is reset versus preserved

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cf0716188327a451da77d034c301)