### PR TITLE
Add logging to diagnose last segment growth rate resets

### DIFF
--- a/app.py
+++ b/app.py
@@ -977,11 +977,22 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
                     last_fit_r = _safe_float(fit_r_list[-1], 0.0)
                     st.session_state["modelfit_r_last_value"] = last_fit_r
                     st.session_state["modelfit_r_last_default"] = last_fit_r
+                    if "modelfit_r_last_input" in st.session_state:
+                        logger.info(
+                            "Dropping modelfit_r_last_input after refitting; last_fit_r=%s",
+                            last_fit_r,
+                        )
                     st.session_state.pop("modelfit_r_last_input", None)
             elif ("modelfit_r_last_value" not in st.session_state) and existing_r:
                 last_existing_r = _safe_float(existing_r[-1], 0.0)
                 st.session_state["modelfit_r_last_value"] = last_existing_r
                 st.session_state["modelfit_r_last_default"] = last_existing_r
+                if "modelfit_r_last_input" in st.session_state:
+                    logger.info(
+                        "Dropping modelfit_r_last_input while seeding from existing_r; "
+                        "last_existing_r=%s",
+                        last_existing_r,
+                    )
                 st.session_state.pop("modelfit_r_last_input", None)
 
             existing_intercepts = coerce_list(st.session_state.get("modelfit_intercepts"))
@@ -1608,7 +1619,25 @@ def sidebar_inputs() -> SimulationInputs:
 
         last_segment_default = float(base_r_list[-1] if base_r_list else organic_default)
         last_default = st.session_state.get("modelfit_r_last_default")
-        if last_default is None or not math.isclose(last_default, last_segment_default, rel_tol=1e-9, abs_tol=1e-9):
+        if last_default is None or not math.isclose(
+            last_default,
+            last_segment_default,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            if last_default is None:
+                logger.info(
+                    "Resetting last segment input because no stored default exists; "
+                    "computed_default=%s",
+                    last_segment_default,
+                )
+            else:
+                logger.info(
+                    "Resetting last segment input due to default drift; "
+                    "stored_default=%s, computed_default=%s",
+                    last_default,
+                    last_segment_default,
+                )
             st.session_state["modelfit_r_last_default"] = last_segment_default
             st.session_state.pop("modelfit_r_last_input", None)
         last_r_val = number_input_state(


### PR DESCRIPTION
## Summary
- add logging when the last segment growth rate widget state is refreshed after a refit or re-seeding from the existing overrides
- log the stored and recomputed defaults when a drift forces the widget state to reset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cf0716188327a451da77d034c301)