### PR TITLE
Add logging around last segment growth rate input

### DIFF
--- a/app.py
+++ b/app.py
@@ -1655,6 +1655,12 @@ def sidebar_inputs() -> SimulationInputs:
                 )
             st.session_state["modelfit_r_last_default"] = last_segment_default
             st.session_state.pop("modelfit_r_last_input", None)
+        logger.info(
+            "Last-segment r defaults: computed=%s, stored=%s, widget_state=%s",
+            last_segment_default,
+            st.session_state.get("modelfit_r_last_default"),
+            st.session_state.get("modelfit_r_last_input"),
+        )
         last_r_val = number_input_state(
             "Last segment growth rate (r)",
             min_value=-10.0,
@@ -1663,6 +1669,8 @@ def sidebar_inputs() -> SimulationInputs:
             step=0.001,
             key="modelfit_r_last_input",
         )
+
+        logger.info("Last-segment r widget returned %s", last_r_val)
 
         if base_r_list:
             r_over = list(base_r_list)


### PR DESCRIPTION
## Summary
- add info-level logging showing computed default, stored default, and existing widget state before rendering the last-segment growth-rate control
- log the value returned from the number input to trace what Streamlit provided

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691589bcfc54832780e4e417dd1c3bd9)