### PR TITLE
Add logging to track last segment growth widget state

### DIFF
--- a/app.py
+++ b/app.py
@@ -985,8 +985,10 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
                     st.session_state["modelfit_r_last_default"] = last_fit_r
                     if "modelfit_r_last_input" in st.session_state:
                         logger.info(
-                            "Dropping modelfit_r_last_input after refitting; last_fit_r=%s",
+                            "Dropping modelfit_r_last_input after refitting; "
+                            "last_fit_r=%s, previous_widget=%s",
                             last_fit_r,
+                            st.session_state.get("modelfit_r_last_input"),
                         )
                     st.session_state.pop("modelfit_r_last_input", None)
             elif ("modelfit_r_last_value" not in st.session_state) and existing_r:
@@ -996,8 +998,9 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
                 if "modelfit_r_last_input" in st.session_state:
                     logger.info(
                         "Dropping modelfit_r_last_input while seeding from existing_r; "
-                        "last_existing_r=%s",
+                        "last_existing_r=%s, previous_widget=%s",
                         last_existing_r,
+                        st.session_state.get("modelfit_r_last_input"),
                     )
                 st.session_state.pop("modelfit_r_last_input", None)
 
@@ -1293,6 +1296,14 @@ def number_input_state(label: str, *, key: str, default_value, **kwargs):
         return isinstance(value, numbers.Number)
 
     current_value = st.session_state.get(key, default_value)
+    if key == "modelfit_r_last_input":
+        logger.info(
+            "number_input_state for %s: stored_value=%s, default_value=%s, key_present=%s",
+            key,
+            current_value,
+            default_value,
+            key in st.session_state,
+        )
 
     if "format" not in kwargs:
         step = kwargs.get("step")


### PR DESCRIPTION
## Summary
- log the previous widget value whenever we drop `modelfit_r_last_input`
- capture the stored versus default values when building the last segment growth widget

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69161f2608dc8327adee2628e55cbe8e)