### PR TITLE
Adjust capacity damping to replace churn near ceiling

### DIFF
--- a/substack_analyzer/model.py
+++ b/substack_analyzer/model.py
@@ -82,18 +82,29 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         if carrying_capacity > 0:
             capacity_multiplier = max(0.0, 1.0 - total_after_churn / carrying_capacity)
 
-        # Organic growth
+        # Organic growth (before capacity adjustment)
         new_free_organic_raw = free_subs * input_params.organic_monthly_growth_rate
-        new_free_organic = new_free_organic_raw * capacity_multiplier
 
-        # Paid acquisition
+        # Paid acquisition (before capacity adjustment)
         ad_spend = float(input_params.ad_spend_schedule.get_spend_for_month(m))
         paid_new = (
             0.0
             if input_params.cost_per_new_free_subscriber <= 0
             else ad_spend / input_params.cost_per_new_free_subscriber
         )
-        new_free_paid = paid_new * capacity_multiplier
+
+        # Apply capacity adjustment while ensuring churn replacement near the ceiling
+        new_free_raw_total = new_free_organic_raw + paid_new
+        overall_multiplier = 1.0 if new_free_raw_total > 0 else 0.0
+        if carrying_capacity > 0 and new_free_raw_total > 0:
+            capacity_gap = max(0.0, carrying_capacity - total_after_churn)
+            base_fill = min(new_free_raw_total, capacity_gap)
+            excess_new = new_free_raw_total - base_fill
+            adjusted_total_new = base_fill + excess_new * capacity_multiplier
+            overall_multiplier = adjusted_total_new / new_free_raw_total if new_free_raw_total > 0 else 0.0
+
+        new_free_organic = new_free_organic_raw * overall_multiplier
+        new_free_paid = paid_new * overall_multiplier
 
         # Add new free
         new_free_total = new_free_organic + new_free_paid

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,4 +30,33 @@ def test_simulate_growth_basic():
     assert (df["net_revenue"] >= 0).all()
 
 
+def test_carrying_capacity_replaces_churn_near_ceiling():
+    inputs = SimulationInputs(
+        starting_free_subscribers=8000,
+        starting_premium_subscribers=1500,
+        carrying_capacity=10000,
+        horizon_months=36,
+        organic_monthly_growth_rate=0.06,
+        monthly_churn_rate_free=0.02,
+        monthly_churn_rate_premium=0.02,
+        new_subscriber_premium_conv_rate=0.01,
+        ongoing_premium_conv_rate=0.0002,
+        cost_per_new_free_subscriber=2.0,
+        ad_spend_schedule=AdSpendSchedule.constant(0.0),
+        ad_manager_monthly_fee=0.0,
+        premium_monthly_price_gross=10.0,
+        substack_fee_pct=0.10,
+        stripe_fee_pct=0.036,
+        stripe_flat_fee=0.30,
+        annual_share=0.0,
+        premium_annual_price_gross=70.0,
+    )
+
+    result = simulate_growth(inputs)
+    df = result.monthly
+
+    tail = df["total_subscribers"].iloc[-6:]
+    assert tail.iloc[-1] >= tail.iloc[0]
+
+
 # end


### PR DESCRIPTION
## Summary
- ensure the simulator lets new free subscribers replace churn when the audience sits near the carrying capacity
- keep the organic and paid acquisition mix proportional while applying the capacity throttle
- add a regression test that checks total subscribers hold steady near the ceiling instead of steadily declining

## Testing
- pytest tests/test_model.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916316cbe3483279448a4881db25876)