### PR TITLE
Remove noise from synthetic logistic series

### DIFF
--- a/scripts/e2e_walkthrough.py
+++ b/scripts/e2e_walkthrough.py
@@ -27,14 +27,13 @@ VISUALIZE = os.getenv("E2E_VISUALIZE", "1") != "0"
 
 
 def _make_synthetic_series(n_months: int = 48, seed: int = 7) -> pd.Series:
-    rng = np.random.default_rng(seed)
     idx = pd.period_range("2022-01", periods=n_months, freq="M").to_timestamp("M")
     values: list[float] = []
     s = 200.0
     for t in range(n_months):
         r = 0.12 if t < (n_months // 2) else 0.05
         K = 15000.0
-        delta = r * s * (1.0 - s / K) + rng.normal(0.0, 15.0)
+        delta = r * s * (1.0 - s / K)
         s = max(s + delta, 0.0)
         values.append(s)
     return pd.Series(values, index=idx, name="Total")

--- a/tests/test_e2e_walkthrough.py
+++ b/tests/test_e2e_walkthrough.py
@@ -32,7 +32,6 @@ def _make_synthetic_series(
 
     K is the carrying capacity.
     """
-    rng = np.random.default_rng(seed)
     idx = pd.period_range("2022-01", periods=n_months, freq="M").to_timestamp("M")
 
     # Determine growth rates for each segment
@@ -50,9 +49,10 @@ def _make_synthetic_series(
     for seg in range(n_segments):
         r = rates[seg]
         for t in range(segment_bounds[seg], segment_bounds[seg + 1]):
-            delta = r * start_value * (1.0 - start_value / K) + rng.normal(0.0, 15.0)
+            delta = r * start_value * (1.0 - start_value / K)
             s = max(start_value + delta, 0.0)
             values.append(s)
+            start_value = s
 
     return pd.Series(values, index=idx, name="Total").round().astype(int)
 


### PR DESCRIPTION
## Summary
- remove Gaussian noise from the synthetic logistic series used by the headless E2E test and walkthrough script
- ensure the headless generator updates its state each step so the series follows a deterministic logistic trajectory

## Testing
- pytest tests/test_e2e_walkthrough.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c62855008327ac868fd7b65f0255)