### PR TITLE
Show intercept term in phase 1 equation displays

### DIFF
--- a/app.py
+++ b/app.py
@@ -1102,7 +1102,7 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
             # ----- latex equation & stash for simulator tab -----
             eq = (
                 r"\Delta S_t = r_{seg(t)}\, S_{t-1} \left(1 - \frac{S_{t-1}}{K}\right) "
-                r"+ \gamma_{pulse}\,pulse_t + \gamma_{step}\,step_t"
+                r"+ \alpha_{seg(t)} + \gamma_{pulse}\,pulse_t + \gamma_{step}\,step_t"
             )
             if getattr(fit, "gamma_exog", None) is not None:
                 eq += r" + \gamma_{exog}\,x_t"
@@ -1116,6 +1116,13 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
                     with suppress(Exception):
                         last_r_text = f"{float(r_list_now[-1]):0.3f}"
                 st.markdown(f"- **Last segment growth rate (r)**: {last_r_text}")
+                intercepts_text = "—"
+                if intercepts_now:
+                    try:
+                        intercepts_text = ", ".join(f"{float(val):0.3f}" for val in intercepts_now)
+                    except Exception:
+                        intercepts_text = ", ".join(str(val) for val in intercepts_now)
+                st.markdown(f"- **Segment intercepts (α)**: {intercepts_text}")
                 st.markdown(f"- **γ_pulse**: {gp_now:0.4f}")
                 st.markdown(f"- **γ_step**: {gs_now:0.4f}")
                 if gx_now is not None:

--- a/scripts/run_headless.py
+++ b/scripts/run_headless.py
@@ -463,13 +463,14 @@ def run(
     try:
         eq = (
             r"$\\Delta S_t = r_{seg(t)} \\, S_{t-1} \\left(1 - \\frac{S_{t-1}}{K}\\right) "
-            r"+ \\gamma_{pulse}\\,pulse_t + \\gamma_{step}\\,step_t$"
+            r"+ \\alpha_{seg(t)} + \\gamma_{pulse}\\,pulse_t + \\gamma_{step}\\,step_t$"
         )
         if getattr(fit, "gamma_exog", None) is not None:
             eq = eq[:-1] + r" + \\gamma_{exog}\\,x_t$"
 
         k_now = getattr(fit, "carrying_capacity", None)
         r_list = coerce_list(getattr(fit, "segment_growth_rates", None))
+        intercept_list = coerce_list(getattr(fit, "segment_intercepts", None))
         gp = getattr(fit, "gamma_pulse", None)
         gs = getattr(fit, "gamma_step", None)
         gx = getattr(fit, "gamma_exog", None)
@@ -484,6 +485,8 @@ def run(
             lines.append(f"- K (capacity): {float(k_now):,.0f}")
         if r_list:
             lines.append("- Segment growth rates r_j: " + ", ".join(f"{r:0.3f}" for r in r_list))
+        if intercept_list:
+            lines.append("- Segment intercepts α_j: " + ", ".join(f"{a:0.3f}" for a in intercept_list))
         if gp is not None:
             lines.append(f"- gamma_pulse: {float(gp):0.4f}")
         if gs is not None:


### PR DESCRIPTION
## Summary
- display the segment intercept term alongside the logistic contribution in the Phase 1 LaTeX equation used by the app and headless runner
- surface the fitted segment intercept values in the app and headless equation summary so the documentation matches the calibrated model

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c55b0d648327b5f44c9c642b6634)