### PR TITLE
Align forecast_piecewise_logistic with documented dynamics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1132,12 +1132,18 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
             if horizon_ahead > 0:
                 last_val = float(fitted_from_overrides.iloc[-1])
                 last_r = float(r_list_now[-1]) if r_list_now else 0.0
+                last_intercept = float(getattr(fit, "gamma_intercept", 0.0))
+                if intercepts_now:
+                    with suppress(Exception):
+                        last_intercept = float(intercepts_now[-1])
                 fc = forecast_piecewise_logistic(
                     last_value=last_val,
                     months_ahead=horizon_ahead,
                     carrying_capacity=float(K_now),
                     segment_growth_rate=float(last_r),
+                    segment_intercept=last_intercept,
                     gamma_step_level=float(gs_now),
+                    gamma_exog=(float(gx_now) if gx_now is not None else None),
                 )
                 fc_index = pd.date_range(
                     fitted_from_overrides.index[-1] + pd.offsets.MonthEnd(1),

--- a/substack_analyzer/calibration.py
+++ b/substack_analyzer/calibration.py
@@ -288,20 +288,67 @@ def forecast_piecewise_logistic(
     months_ahead: int,
     carrying_capacity: float,
     segment_growth_rate: float,
+    segment_intercept: float = 0.0,
     gamma_pulse: float = 0.0,
     gamma_step_level: float = 0.0,
+    gamma_exog: float | None = None,
+    exog_future: Sequence[float] | None = None,
+    pulse_sequence: Sequence[float] | None = None,
 ) -> np.ndarray:
-    """Simple forward simulation with constant parameters for months_ahead.
+    """Forward simulation for the last segment using the documented dynamics.
 
-    Uses the final segment's growth rate and optional constant step level.
+    Parameters mirror the fitted equation:
+
+    ΔS_t = r * S_{t-1} (1 - S_{t-1} / K) + α + γ_pulse pulse_t + γ_step step_t + γ_exog x_t
+
+    The `gamma_step_level` argument represents the current step regressor level
+    (typically 0.0 or 1.0) multiplied by its coefficient and is assumed constant
+    over the forecast horizon.  A `pulse_sequence` can be supplied to control
+    future pulses; by default a one-time pulse is applied on the first step to
+    match the historical behaviour.  When `exog_future` is provided and
+    `gamma_exog` is not ``None``, the exogenous contribution is applied
+    element-wise.
     """
+
+    months = max(int(months_ahead), 0)
+    if months == 0:
+        return np.empty(0, dtype=float)
+
     values = [float(last_value)]
-    for _ in range(months_ahead):
-        x_t = values[-1] * (1.0 - values[-1] / carrying_capacity)
-        delta = segment_growth_rate * x_t + gamma_step_level
-        values.append(max(values[-1] + delta + gamma_pulse, 0.0))
-        # Only apply pulse in first step
-        gamma_pulse = 0.0
+
+    if pulse_sequence is None:
+        pulses = [1.0] + [0.0] * max(months - 1, 0)
+    else:
+        pulses = [float(p) for p in pulse_sequence[:months]]
+        if len(pulses) < months:
+            pulses.extend([0.0] * (months - len(pulses)))
+
+    if exog_future is None:
+        exog_vals = [0.0] * months
+    else:
+        exog_vals = [float(val) for val in exog_future[:months]]
+        if len(exog_vals) < months:
+            exog_vals.extend([0.0] * (months - len(exog_vals)))
+
+    intercept = float(segment_intercept)
+    step_level = float(gamma_step_level)
+    growth_rate = float(segment_growth_rate)
+    gamma_p = float(gamma_pulse)
+    gamma_ex = None if gamma_exog is None else float(gamma_exog)
+    capacity = float(carrying_capacity)
+
+    for step_idx in range(months):
+        prev = values[-1]
+        if capacity <= 0:
+            x_t = 0.0
+        else:
+            x_t = prev * (1.0 - prev / capacity)
+        delta = growth_rate * x_t + intercept + step_level
+        delta += gamma_p * pulses[step_idx]
+        if gamma_ex is not None:
+            delta += gamma_ex * exog_vals[step_idx]
+        values.append(max(prev + delta, 0.0))
+
     return np.array(values[1:], dtype=float)
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -31,6 +31,23 @@ def test_forecast_piecewise_logistic_shapes():
     assert (out >= 0).all()
 
 
+def test_forecast_piecewise_logistic_applies_intercept_and_exog():
+    out = forecast_piecewise_logistic(
+        last_value=100.0,
+        months_ahead=3,
+        carrying_capacity=500.0,
+        segment_growth_rate=0.0,
+        segment_intercept=10.0,
+        gamma_pulse=5.0,
+        gamma_step_level=1.5,
+        gamma_exog=2.0,
+        exog_future=[1.0, 2.0, 3.0],
+        pulse_sequence=[0.0, 1.0, 0.0],
+    )
+    expected = np.array([113.5, 134.0, 151.5])
+    assert np.allclose(out, expected)
+
+
 def test_fit_piecewise_logistic_requires_minimum_length():
     idx = pd.period_range("2024-01", periods=3, freq="M").to_timestamp("M")
     s = pd.Series([100, 101, 102], index=idx)


### PR DESCRIPTION
## Summary
- extend the simple forecast helper to apply the documented intercept, pulse, step, and optional exogenous contributions
- plumb the fitted last-segment intercept into the UI forecast call so forward projections include the fitted baseline
- add a regression test that verifies intercept and exogenous inputs are reflected in the forecast output

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d33870388327863b960e07c60870)