### PR TITLE
Update two-stage ad spend to year 1 and year 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Notes:
 - Pricing and fees:
   - Substack fee 10%, Stripe 3.6% + $0.30 are defaults; update as needed.
 - Ad spend schedule:
-  - Two-stage lets you specify a higher budget in years 1–2 and lower in years 3–5; constant uses a flat monthly spend.
+  - Two-stage lets you specify a budget for year 1 and a different budget for year 2 and beyond; constant uses a flat monthly spend.
 
 ## Notes and limitations (MVP)
 

--- a/app.py
+++ b/app.py
@@ -1478,7 +1478,7 @@ def sidebar_inputs() -> SimulationInputs:
         )
 
     with st.sidebar.expander("Acquisition", expanded=True):
-        spend_mode_options = ["Two-stage (Years 1-2 / 3-5)", "Constant", "One-time"]
+        spend_mode_options = ["Two-stage (Year 1 / Year 2+)", "Constant", "One-time"]
         spend_mode_index = int(_get_state("spend_mode_index", 1))
         spend_mode_index = max(0, min(spend_mode_index, len(spend_mode_options) - 1))
         spend_mode = st.selectbox(
@@ -1490,14 +1490,14 @@ def sidebar_inputs() -> SimulationInputs:
         one_time_trigger_idx = None
         if spend_mode.startswith("Two-stage"):
             stage1 = number_input_state(
-                "Monthly ad spend (years 1-2)",
+                "Monthly ad spend (year 1)",
                 min_value=0.0,
                 default_value=float(_get_state("ad_stage1", 0.0)),
                 step=50.0,
                 key="ad_stage1",
             )
             stage2 = number_input_state(
-                "Monthly ad spend (years 3-5)",
+                "Monthly ad spend (year 2+)",
                 min_value=0.0,
                 default_value=float(_get_state("ad_stage2", 0.0)),
                 step=50.0,

--- a/scripts/run_simulator.py
+++ b/scripts/run_simulator.py
@@ -360,7 +360,7 @@ def main() -> None:
         metavar=("STAGE1", "STAGE2"),
         type=float,
         default=None,
-        help="Two-stage spend (years 1-2, years 3-5)",
+        help="Two-stage spend (year 1 and year 2+)",
     )
     g.add_argument(
         "--spend-once", dest="spend_once", type=float, default=None, help="One-time ad spend in a single month"

--- a/substack_analyzer/types.py
+++ b/substack_analyzer/types.py
@@ -53,12 +53,12 @@ class AdSpendSchedule:
         return AdSpendSchedule(lambda _m: float(monthly_spend))
 
     @staticmethod
-    def two_stage(years_1_to_2: float, years_3_to_5: float) -> "AdSpendSchedule":
+    def two_stage(year_1: float, year_2: float) -> "AdSpendSchedule":
         def _spend(month_index: int) -> float:
-            # Months are 0-indexed. Years 1-2: months 0..23, Years 3-5: months 24..59
-            if month_index < 24:
-                return float(years_1_to_2)
-            return float(years_3_to_5)
+            # Months are 0-indexed. Year 1: months 0..11, Year 2 and beyond: months 12+
+            if month_index < 12:
+                return float(year_1)
+            return float(year_2)
 
         return AdSpendSchedule(_spend)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,8 +8,8 @@ def test_adspend_constant_and_two_stage():
 
     two = AdSpendSchedule.two_stage(3000.0, 1000.0)
     assert two.get_spend_for_month(0) == 3000.0
-    assert two.get_spend_for_month(23) == 3000.0
-    assert two.get_spend_for_month(24) == 1000.0
+    assert two.get_spend_for_month(11) == 3000.0
+    assert two.get_spend_for_month(12) == 1000.0
 
 
 def test_simulation_inputs_defaults():


### PR DESCRIPTION
## Summary
- adjust two-stage ad spend schedule to split year 1 from year 2 and later months
- refresh sidebar labels, CLI help text, and README guidance to match the new stages
- update schedule test coverage for the revised year break

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ceed847908327a768ab69070f2d71)