### PR TITLE
Add scenario tests for massive one-time spike

### DIFF
--- a/substack_analyzer/scenarios.py
+++ b/substack_analyzer/scenarios.py
@@ -414,6 +414,44 @@ def exog_with_nans_series_and_exog() -> tuple[pd.Series, pd.Series]:
     return s, exog_series.astype(float)
 
 
+def massive_spike_single_month_series(
+    include_external_event: bool = True,
+) -> tuple[pd.Series, pd.DataFrame | None]:
+    """
+    Series with steady growth that experiences a single, enormous one-month spike.
+
+    When ``include_external_event`` is True, the spike month is annotated as a
+    transient external event so calibration can attribute the jump to
+    ``gamma_pulse``. When False, the fitter must explain the jump organically,
+    which leads to unrealistic growth-rate estimates.
+    """
+
+    idx = pd.period_range("2023-01", periods=18, freq="M").to_timestamp("M")
+
+    # Steady organic growth punctuated by a one-time surge in the 9th delta
+    start = 20_000.0
+    deltas = [1_200.0] * (len(idx) - 1)
+    spike_delta_idx = 8
+    deltas[spike_delta_idx] = 120_000.0
+
+    vals = [start]
+    for delta in deltas:
+        vals.append(vals[-1] + delta)
+    series = pd.Series(vals, index=idx)
+
+    events_df: pd.DataFrame | None = None
+    if include_external_event:
+        events_df = pd.DataFrame(
+            {
+                "date": [idx[spike_delta_idx + 1]],
+                "type": ["external viral moment"],
+                "persistence": ["Transient"],
+            }
+        )
+
+    return series, events_df
+
+
 def three_breaks_mixed_persistence_params() -> dict:
     """
     Parameters and events for a synthetic series with three breakpoints and mixed persistence.

--- a/tests/test_calibration_scenarios.py
+++ b/tests/test_calibration_scenarios.py
@@ -6,6 +6,7 @@ from substack_analyzer.detection import detect_change_points
 from substack_analyzer.scenarios import (
     mid_sized_seasonal_conference_series,
     niche_steady_series,
+    massive_spike_single_month_series,
     scenario_ads_really_valuable,
     small_breakout_series,
     top_tier_sustained_marketing_series,
@@ -84,3 +85,23 @@ def test_phase1_ads_really_valuable_fit_with_exog():
     # Deterministic construction; should explain nearly all variance in deltas
     assert fit.r2_on_deltas > 0.95
     assert fit.sse <= 50
+
+
+def test_massive_spike_with_external_event_has_grounded_growth_rate():
+    series, events_df = massive_spike_single_month_series(include_external_event=True)
+
+    fit = fit_piecewise_logistic(series, breakpoints=[], events_df=events_df)
+
+    assert len(fit.segment_growth_rates) == 1
+    assert abs(fit.segment_growth_rates[0]) < 0.01
+    assert fit.sse < 1.0
+
+
+def test_massive_spike_without_external_event_has_wild_growth_rate():
+    series, _events_df = massive_spike_single_month_series(include_external_event=False)
+
+    fit = fit_piecewise_logistic(series, breakpoints=[])
+
+    assert len(fit.segment_growth_rates) == 1
+    assert abs(fit.segment_growth_rates[0]) > 0.05
+    assert fit.sse > 1_000_000_000


### PR DESCRIPTION
## Summary
- add a reusable scenario with a single massive subscriber spike that can be annotated as an external event
- verify calibration stays grounded when the spike is explained by an event and goes off the rails when it is not

## Testing
- python -m pytest tests/test_calibration_scenarios.py -k "massive_spike"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf4a1aae88327a699e59f491b4d8d)