### PR TITLE
Extract FAQ content into separate module

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,7 @@ from substack_analyzer.changepoints import (
 )
 from substack_analyzer.detection import compute_segment_slopes, slope_around
 from substack_analyzer.model import simulate_growth
+from substack_analyzer.faq import FAQ_ITEMS
 from substack_analyzer.persistence import (
     apply_phase_one_json,
     apply_session_bundle,
@@ -2040,6 +2041,13 @@ def render_help() -> None:
 Use the Estimators tab to turn exports into these inputs, then paste the results into the Simulator sidebar.
         """
     )
+
+    st.markdown("---")
+    st.subheader("Frequently asked questions")
+    for item in FAQ_ITEMS:
+        st.markdown(f"**{item['question']}**")
+        st.markdown(item["answer"])
+        st.write("")
 
 
 def render_save_load() -> None:

--- a/substack_analyzer/faq.py
+++ b/substack_analyzer/faq.py
@@ -1,0 +1,42 @@
+"""Frequently asked questions content for the Help tab."""
+
+from __future__ import annotations
+
+
+FAQ_ITEMS = [
+    {
+        "question": "How does the simulator move free subscribers to paid (and vice versa)?",
+        "answer": (
+            "Free cohorts upgrade to paid through two conversion rates in the deterministic equations: "
+            "`p_new` (new-subscriber premium conversion) applies to brand-new free signups each month, "
+            "and `p_ongoing` (ongoing premium conversion) applies to the existing free base. The conversions "
+            "subtract from free and add to paid in the same month. Paid does not downgrade back to free; "
+            "instead, churn rates (`c_f`, `c_p`) remove subscribers from each cohort."
+        ),
+    },
+    {
+        "question": "When does the Help tab update its growth equation?",
+        "answer": (
+            "When you run Stage 4 of the Estimators tab, the fitted piecewise logistic equation is stored in "
+            "session state and displayed here. If you have not fit a model yet, the Help tab shows the default "
+            "deterministic cohort equations used by the Simulator sidebar."
+        ),
+    },
+    {
+        "question": "How should I choose the ad spend schedule inputs?",
+        "answer": (
+            "Use the two-stage schedule to set one monthly spend level for months 0–23 and another for months "
+            "24–59 when planning ramped campaigns. Use the constant spend option when you have a flat budget. "
+            "Both options drive the same cohort equations and CAC calculations."
+        ),
+    },
+    {
+        "question": "What should I do before loading a session bundle?",
+        "answer": (
+            "If you import new data, first download the current bundle from Save / Load to avoid losing work. "
+            "When you upload a bundle, the app restores events, fits, and simulator inputs, and will switch to "
+            "the Simulator tab automatically."
+        ),
+    },
+]
+


### PR DESCRIPTION
## Summary
- move FAQ items into a dedicated `substack_analyzer/faq.py` module
- import the shared FAQ content into the Help tab renderer in `app.py`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf98507f483279f803cef05b85029)