### PR TITLE
Update FAQ to clarify premium subscriber growth

### DIFF
--- a/substack_analyzer/faq.py
+++ b/substack_analyzer/faq.py
@@ -4,11 +4,14 @@ FAQ_ITEMS = [
     {
         "question": "How does the simulator move free subscribers to paid (and vice versa)?",
         "answer": (
-            "Free cohorts upgrade to paid through two conversion rates in the deterministic equations: "
-            "`p_new` (new-subscriber premium conversion) applies to brand-new free signups each month, "
-            "and `p_ongoing` (ongoing premium conversion) applies to the existing free base. The conversions "
-            "subtract from free and add to paid in the same month. Paid does not downgrade back to free; "
-            "instead, churn rates (`c_f`, `c_p`) remove subscribers from each cohort."
+            "The simulator only grows the free audience directly—through an organic month-over-month rate "
+            "and any paid acquisition you fund (ad spend divided by CAC, modified by the ad-response curve "
+            "and carrying-capacity damping). Paid subscribers increase by converting a share of that free "
+            "audience: a percentage of the current month’s new free signups convert immediately, and a "
+            "smaller ongoing percentage of the existing free base converts every month. Those conversions "
+            "are added to the premium pool while being removed from the free pool. Premium churn is then "
+            "applied monthly to the premium pool, so net premium growth equals conversions minus churn—"
+            "there’s no standalone premium growth rate, just conversion from free plus churn effects."
         ),
     },
     {


### PR DESCRIPTION
## Summary
- clarify the FAQ entry on how premium subscribers grow, emphasizing free audience growth, conversion, and churn

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cfb3689b08327b50e0fc11501e46f)