### PR TITLE
Expose premium acquisition controls in simulator UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1478,84 +1478,95 @@ def sidebar_inputs() -> SimulationInputs:
             key="conv_ongoing",
         )
 
-    with st.sidebar.expander("Acquisition", expanded=True):
+    def _spend_controls(prefix: str, label_prefix: str, default_index: int = 1) -> tuple[AdSpendSchedule, int | None]:
         spend_mode_options = ["Two-stage (Year 1 / Year 2+)", "Constant", "One-time"]
-        spend_mode_index = int(_get_state("spend_mode_index", 1))
+        spend_mode_index = int(_get_state(f"{prefix}_spend_mode_index", default_index))
         spend_mode_index = max(0, min(spend_mode_index, len(spend_mode_options) - 1))
         spend_mode = st.selectbox(
-            "Ad spend schedule",
+            f"Ad spend schedule ({label_prefix})",
             spend_mode_options,
             index=spend_mode_index,
-            key="spend_mode",
+            key=f"{prefix}_spend_mode",
         )
         one_time_trigger_idx = None
         if spend_mode.startswith("Two-stage"):
             stage1 = number_input_state(
-                "Monthly ad spend (year 1)",
+                f"Monthly ad spend (year 1, {label_prefix.lower()})",
                 min_value=0.0,
-                default_value=float(_get_state("ad_stage1", 0.0)),
+                default_value=float(_get_state(f"{prefix}_ad_stage1", 0.0)),
                 step=50.0,
-                key="ad_stage1",
+                key=f"{prefix}_ad_stage1",
             )
             stage2 = number_input_state(
-                "Monthly ad spend (year 2+)",
+                f"Monthly ad spend (year 2+, {label_prefix.lower()})",
                 min_value=0.0,
-                default_value=float(_get_state("ad_stage2", 0.0)),
+                default_value=float(_get_state(f"{prefix}_ad_stage2", 0.0)),
                 step=50.0,
-                key="ad_stage2",
+                key=f"{prefix}_ad_stage2",
             )
             stage1 = float(stage1 or 0.0)
             stage2 = float(stage2 or 0.0)
             ad_schedule = AdSpendSchedule.two_stage(stage1, stage2)
-            st.session_state["spend_mode_index"] = 0
+            st.session_state[f"{prefix}_spend_mode_index"] = 0
         elif spend_mode == "Constant":
             const_spend = number_input_state(
-                "Monthly ad spend (constant)",
+                f"Monthly ad spend (constant, {label_prefix.lower()})",
                 min_value=0.0,
-                default_value=float(_get_state("ad_const", 0.0)),
+                default_value=float(_get_state(f"{prefix}_ad_const", 0.0)),
                 step=50.0,
-                key="ad_const",
+                key=f"{prefix}_ad_const",
             )
             const_spend = float(const_spend or 0.0)
             ad_schedule = AdSpendSchedule.constant(const_spend)
-            st.session_state["spend_mode_index"] = 1
+            st.session_state[f"{prefix}_spend_mode_index"] = 1
         else:
             one_time_amount = number_input_state(
-                "One-time ad spend amount",
+                f"One-time ad spend amount ({label_prefix.lower()})",
                 min_value=0.0,
-                default_value=float(_get_state("ad_one_time_amount", 0.0)),
+                default_value=float(_get_state(f"{prefix}_ad_one_time_amount", 0.0)),
                 step=50.0,
-                key="ad_one_time_amount",
+                key=f"{prefix}_ad_one_time_amount",
             )
-            default_month = int(_get_state("ad_one_time_month", 1))
+            default_month = int(_get_state(f"{prefix}_ad_one_time_month", 1))
             horizon_int = max(int(horizon), 1)
             default_month = min(max(default_month, 1), horizon_int)
             one_time_month = number_input_state(
-                "One-time spend month",
+                f"One-time spend month ({label_prefix.lower()})",
                 min_value=1,
                 max_value=horizon_int,
                 default_value=default_month,
                 step=1,
-                key="ad_one_time_month",
+                key=f"{prefix}_ad_one_time_month",
             )
             one_time_amount = float(one_time_amount or 0.0)
             one_time_trigger_idx = max(int(one_time_month or 1) - 1, 0)
             ad_schedule = AdSpendSchedule.one_time(one_time_amount, one_time_trigger_idx)
-            st.session_state["spend_mode_index"] = 2
+            st.session_state[f"{prefix}_spend_mode_index"] = 2
 
-        with st.sidebar.expander("Ad spend preview", expanded=False):
+        return ad_schedule, one_time_trigger_idx
+
+    def _spend_preview(ad_schedule: AdSpendSchedule, trigger_idx: int | None, label: str) -> None:
+        with st.sidebar.expander(f"Ad spend preview ({label})", expanded=False):
             horizon_idx = max(int(horizon) - 1, 0)
             candidates = [0, 11, 23, 35, 59, horizon_idx]
             preview_months = sorted({min(max(m, 0), horizon_idx) for m in candidates})
-            if one_time_trigger_idx is not None and horizon_idx >= 0:
+            if trigger_idx is not None and horizon_idx >= 0:
                 preview_months = sorted(
                     set(preview_months)
-                    | {min(max(one_time_trigger_idx, 0), horizon_idx)}
+                    | {min(max(trigger_idx, 0), horizon_idx)}
                 )
             preview_rows = {
-                f"Month {m + 1}": format_currency(float(ad_schedule.get_spend_for_month(m))) for m in preview_months
+                f"Month {m + 1}": format_currency(float(ad_schedule.get_spend_for_month(m)))
+                for m in preview_months
             }
             st.write("Representative monthly ad spend:", preview_rows)
+
+    with st.sidebar.expander("Acquisition", expanded=True):
+        st.caption("Configure paid acquisition for free signups and premium-direct campaigns.")
+        ad_schedule, one_time_trigger_idx_free = _spend_controls("free", "Free")
+        premium_ad_schedule, one_time_trigger_idx_premium = _spend_controls("premium", "Premium")
+        _spend_preview(ad_schedule, one_time_trigger_idx_free, "Free")
+        _spend_preview(premium_ad_schedule, one_time_trigger_idx_premium, "Premium")
 
         cac = number_input_state(
             "Cost per new free subscriber (CAC)",
@@ -1563,6 +1574,13 @@ def sidebar_inputs() -> SimulationInputs:
             default_value=float(_get_state("cac", 2.0)),
             step=0.1,
             key="cac",
+        )
+        cac_premium = number_input_state(
+            "Cost per new premium subscriber (direct CAC)",
+            min_value=0.01,
+            default_value=float(_get_state("cac_premium", 10.0)),
+            step=0.5,
+            key="cac_premium",
         )
         ad_manager_fee = number_input_state(
             "Ad manager monthly fee",
@@ -1794,10 +1812,30 @@ def sidebar_inputs() -> SimulationInputs:
         carrying_capacity = k_float
     organic_from_fit = float(_r_now[-1]) if (_r_now and len(_r_now) > 0) else float(organic_growth)
 
+    capacity_free = number_input_state(
+        "Free carrying capacity (optional)",
+        min_value=0.0,
+        default_value=float(_get_state("carrying_capacity_free", 0.0)),
+        step=100.0,
+        key="carrying_capacity_free",
+    )
+    capacity_premium = number_input_state(
+        "Premium carrying capacity (optional)",
+        min_value=0.0,
+        default_value=float(_get_state("carrying_capacity_premium", 0.0)),
+        step=100.0,
+        key="carrying_capacity_premium",
+    )
+
+    carrying_capacity_free = float(capacity_free) if float(capacity_free or 0.0) > 0 else None
+    carrying_capacity_premium = float(capacity_premium) if float(capacity_premium or 0.0) > 0 else None
+
     return SimulationInputs(
         starting_free_subscribers=start_free,
         starting_premium_subscribers=start_premium,
         carrying_capacity=carrying_capacity,
+        carrying_capacity_free=carrying_capacity_free,
+        carrying_capacity_premium=carrying_capacity_premium,
         horizon_months=horizon,
         organic_monthly_growth_rate=organic_from_fit,
         monthly_churn_rate_free=float(churn_free),
@@ -1805,7 +1843,9 @@ def sidebar_inputs() -> SimulationInputs:
         new_subscriber_premium_conv_rate=float(conv_new),
         ongoing_premium_conv_rate=float(conv_ongoing),
         cost_per_new_free_subscriber=float(cac),
+        cost_per_new_premium_subscriber=float(cac_premium),
         ad_spend_schedule=ad_schedule,
+        premium_ad_spend_schedule=premium_ad_schedule,
         ad_manager_monthly_fee=float(ad_manager_fee),
         premium_monthly_price_gross=float(price_monthly),
         premium_annual_price_gross=float(price_annual),
@@ -1830,10 +1870,20 @@ def render_kpis(df: pd.DataFrame) -> None:
     col5.metric("Cumulative ad spend", format_currency(last.cumulative_ad_spend))
     roas = 0.0 if last.cumulative_ad_spend == 0 else (df.net_revenue.sum() / df.ad_spend.sum())
     col6.metric("ROAS (net revenue / ad spend)", f"{roas:0.2f}x")
-    avg_cac = float("nan") if df.new_free_paid.sum() == 0 else df.ad_spend.sum() / df.new_free_paid.sum()
-    col7.metric("Blended CAC (paid only)", format_currency(avg_cac))
+    free_paid = df.new_free_paid.sum()
+    free_paid_spend = df.ad_spend_free.sum()
+    avg_cac_free = float("nan") if free_paid == 0 else free_paid_spend / free_paid
+    col7.metric("Blended free CAC (paid only)", format_currency(avg_cac_free))
     payback_month = next((i + 1 for i, c in enumerate(df.cumulative_net_profit) if c > 0), math.nan)
     col8.metric("Payback month (cumulative)", "—" if math.isnan(payback_month) else str(int(payback_month)))
+
+    col9, col10, col11, _ = st.columns(4)
+    premium_paid = df.new_premium_paid.sum() if "new_premium_paid" in df.columns else 0
+    premium_paid_spend = df.ad_spend_premium.sum() if "ad_spend_premium" in df.columns else 0
+    avg_cac_premium = float("nan") if premium_paid == 0 else premium_paid_spend / premium_paid
+    col9.metric("Blended premium CAC (paid only)", format_currency(avg_cac_premium))
+    col10.metric("Premium ad spend", format_currency(df.ad_spend_premium.sum()))
+    col11.metric("Free ad spend", format_currency(df.ad_spend_free.sum()))
 
 
 def render_charts(df: pd.DataFrame) -> None:

--- a/substack_analyzer/model.py
+++ b/substack_analyzer/model.py
@@ -42,11 +42,14 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         "total_subscribers",
         "new_free_organic",
         "new_free_paid",
+        "new_premium_paid",
         "free_churned",
         "premium_converted_from_new",
         "premium_converted_from_existing",
         "premium_churned",
         "ad_spend",
+        "ad_spend_free",
+        "ad_spend_premium",
         "ad_manager_fee",
         "mrr_gross",
         "mrr_net",
@@ -65,7 +68,8 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
 
     cumulative_ad_spend = 0.0
     cumulative_net_profit = 0.0
-    prev_adstock = 0.0
+    prev_adstock_free = 0.0
+    prev_adstock_premium = 0.0
 
     for m in months:
         # Beginning-of-month churn
@@ -76,62 +80,109 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         premium_subs -= premium_churned
 
         # Capacity pressure: scale organic/paid acquisition as the audience
-        # approaches the inferred carrying capacity (if provided).
-        total_after_churn = free_subs + premium_subs
-        capacity_multiplier = 1.0
-        carrying_capacity = input_params.carrying_capacity or 0.0
-        if carrying_capacity > 0:
-            capacity_multiplier = max(0.0, 1.0 - total_after_churn / carrying_capacity)
+        # approaches the inferred carrying capacity (if provided). Prefer
+        # segment-specific ceilings when available.
+        carrying_capacity_shared = input_params.carrying_capacity or 0.0
+        carrying_capacity_free = (
+            carrying_capacity_shared
+            if input_params.carrying_capacity_free is None
+            else float(input_params.carrying_capacity_free)
+        )
+        carrying_capacity_premium = (
+            0.0
+            if input_params.carrying_capacity_premium is None
+            else float(input_params.carrying_capacity_premium)
+        )
+        capacity_multiplier_free = 1.0
+        free_capacity_denominator = free_subs
+        free_capacity_gap = float("inf")
+        if carrying_capacity_free > 0:
+            use_shared_free = input_params.carrying_capacity_free is None and carrying_capacity_shared > 0
+            free_capacity_denominator = free_subs + premium_subs if use_shared_free else free_subs
+            free_capacity_gap = max(0.0, carrying_capacity_free - free_capacity_denominator)
+            capacity_multiplier_free = max(0.0, 1.0 - free_capacity_denominator / carrying_capacity_free)
 
         # Organic growth (before capacity adjustment)
         new_free_organic_raw = free_subs * input_params.organic_monthly_growth_rate
 
         # Paid acquisition (before capacity adjustment)
-        ad_spend = float(input_params.ad_spend_schedule.get_spend_for_month(m))
+        ad_spend_free = float(input_params.ad_spend_schedule.get_spend_for_month(m))
+        ad_spend_premium = float(input_params.premium_ad_spend_schedule.get_spend_for_month(m))
 
         # Adstock with diminishing-returns response: log(1 + adstock/theta)
-        adstock = ad_spend + input_params.adstock_lambda * prev_adstock
-        prev_adstock = adstock
+        adstock_free = ad_spend_free + input_params.adstock_lambda * prev_adstock_free
+        prev_adstock_free = adstock_free
 
-        paid_new_base = (
+        adstock_premium = ad_spend_premium + input_params.adstock_lambda * prev_adstock_premium
+        prev_adstock_premium = adstock_premium
+
+        paid_new_free_base = (
             0.0
             if input_params.cost_per_new_free_subscriber <= 0
-            else ad_spend / input_params.cost_per_new_free_subscriber
+            else ad_spend_free / input_params.cost_per_new_free_subscriber
+        )
+        paid_new_premium_base = (
+            0.0
+            if input_params.cost_per_new_premium_subscriber <= 0
+            else ad_spend_premium / input_params.cost_per_new_premium_subscriber
         )
 
-        if adstock > 0 and input_params.ad_log_theta > 0:
-            response = np.log1p(adstock / input_params.ad_log_theta)
-            diminishing_multiplier = response / (adstock / input_params.ad_log_theta)
-        else:
-            diminishing_multiplier = 0.0 if adstock <= 0 else 1.0
+        def _diminishing_multiplier(adstock_val: float) -> float:
+            if adstock_val > 0 and input_params.ad_log_theta > 0:
+                response_val = np.log1p(adstock_val / input_params.ad_log_theta)
+                return response_val / (adstock_val / input_params.ad_log_theta)
+            if adstock_val <= 0:
+                return 0.0
+            return 1.0
 
-        paid_new = paid_new_base * diminishing_multiplier
+        paid_new_free = paid_new_free_base * _diminishing_multiplier(adstock_free)
+        paid_new_premium = paid_new_premium_base * _diminishing_multiplier(adstock_premium)
 
         # Apply capacity adjustment while ensuring churn replacement near the ceiling
-        new_free_raw_total = new_free_organic_raw + paid_new
+        new_free_raw_total = new_free_organic_raw + paid_new_free
         overall_multiplier = 1.0 if new_free_raw_total > 0 else 0.0
-        if carrying_capacity > 0 and new_free_raw_total > 0:
-            capacity_gap = max(0.0, carrying_capacity - total_after_churn)
-            base_fill = min(new_free_raw_total, capacity_gap)
-            excess_new = new_free_raw_total - base_fill
-            adjusted_total_new = base_fill + excess_new * capacity_multiplier
-            overall_multiplier = adjusted_total_new / new_free_raw_total if new_free_raw_total > 0 else 0.0
+        if carrying_capacity_free > 0 and new_free_raw_total > 0:
+            base_fill_free = min(new_free_raw_total, free_capacity_gap)
+            excess_new_free = new_free_raw_total - base_fill_free
+            adjusted_total_new_free = base_fill_free + excess_new_free * capacity_multiplier_free
+            overall_multiplier = (
+                adjusted_total_new_free / new_free_raw_total if new_free_raw_total > 0 else 0.0
+            )
 
         new_free_organic = new_free_organic_raw * overall_multiplier
-        new_free_paid = paid_new * overall_multiplier
+        new_free_paid = paid_new_free * overall_multiplier
 
         # Add new free
         new_free_total = new_free_organic + new_free_paid
         free_subs += new_free_total
 
         # Conversions to premium
-        convert_from_new = new_free_total * input_params.new_subscriber_premium_conv_rate
-        convert_from_existing = max(free_subs - new_free_total, 0.0) * input_params.ongoing_premium_conv_rate
+        convert_from_new_raw = new_free_total * input_params.new_subscriber_premium_conv_rate
+        convert_from_existing_raw = max(free_subs - new_free_total, 0.0) * input_params.ongoing_premium_conv_rate
+
+        # Premium paid acquisition (direct to premium)
+        premium_inflow_raw = convert_from_new_raw + convert_from_existing_raw + paid_new_premium
+        premium_multiplier = 1.0 if premium_inflow_raw > 0 else 0.0
+        if carrying_capacity_premium > 0 and premium_inflow_raw > 0:
+            capacity_gap_premium = max(0.0, carrying_capacity_premium - premium_subs)
+            base_fill_premium = min(premium_inflow_raw, capacity_gap_premium)
+            excess_premium = premium_inflow_raw - base_fill_premium
+            capacity_multiplier_premium = max(
+                0.0, 1.0 - (premium_subs + base_fill_premium) / carrying_capacity_premium
+            )
+            adjusted_total_premium = base_fill_premium + excess_premium * capacity_multiplier_premium
+            premium_multiplier = (
+                adjusted_total_premium / premium_inflow_raw if premium_inflow_raw > 0 else 0.0
+            )
+
+        convert_from_new = convert_from_new_raw * premium_multiplier
+        convert_from_existing = convert_from_existing_raw * premium_multiplier
+        paid_new_premium_adjusted = paid_new_premium * premium_multiplier
 
         # Apply conversions: move from free to premium
         total_convert = convert_from_new + convert_from_existing
         free_subs = max(free_subs - total_convert, 0.0)
-        premium_subs += total_convert
+        premium_subs += total_convert + paid_new_premium_adjusted
 
         # Revenue
         # Split premium base into monthly vs annual cohorts
@@ -146,10 +197,11 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
 
         net_revenue = mrr_net + annual_revenue_net_month
 
-        ad_manager_fee = input_params.ad_manager_monthly_fee if ad_spend > 0 else 0.0
-        profit = net_revenue - ad_spend - ad_manager_fee
+        ad_spend_total = ad_spend_free + ad_spend_premium
+        ad_manager_fee = input_params.ad_manager_monthly_fee if ad_spend_total > 0 else 0.0
+        profit = net_revenue - ad_spend_total - ad_manager_fee
 
-        cumulative_ad_spend += ad_spend
+        cumulative_ad_spend += ad_spend_total
         cumulative_net_profit += profit
 
         total_subscribers = free_subs + premium_subs
@@ -162,11 +214,14 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
                 total_subscribers,
                 new_free_organic,
                 new_free_paid,
+                paid_new_premium_adjusted,
                 free_churned,
                 convert_from_new,
                 convert_from_existing,
                 premium_churned,
-                ad_spend,
+                ad_spend_total,
+                ad_spend_free,
+                ad_spend_premium,
                 ad_manager_fee,
                 mrr_gross,
                 mrr_net,
@@ -191,6 +246,7 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         "premium_converted_from_new",
         "premium_converted_from_existing",
         "premium_churned",
+        "new_premium_paid",
     ]
     for _col in flow_cols:
         if _col in monthly_df.columns:
@@ -199,6 +255,8 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
     # Round monetary columns to whole dollars
     money_cols = [
         "ad_spend",
+        "ad_spend_free",
+        "ad_spend_premium",
         "ad_manager_fee",
         "mrr_gross",
         "mrr_net",

--- a/substack_analyzer/types.py
+++ b/substack_analyzer/types.py
@@ -78,9 +78,13 @@ class SimulationInputs:
     starting_free_subscribers: int = 0
     starting_premium_subscribers: int = 0
 
-    # Optional carrying capacity (total subscribers) that damps growth as the
-    # audience approaches the inferred ceiling from Phase 1 fits.
+    # Optional carrying capacities that damp growth as the audience approaches
+    # the inferred ceiling from Phase 1 fits. If segment-specific capacities
+    # are provided they take precedence; otherwise `carrying_capacity` is used
+    # as a shared ceiling for both free and premium.
     carrying_capacity: float | None = None
+    carrying_capacity_free: float | None = None
+    carrying_capacity_premium: float | None = None
 
     # Horizon
     horizon_months: int = 60
@@ -96,7 +100,9 @@ class SimulationInputs:
 
     # Acquisition
     cost_per_new_free_subscriber: float = 2.00
+    cost_per_new_premium_subscriber: float = 10.00
     ad_spend_schedule: AdSpendSchedule = AdSpendSchedule.two_stage(3000.0, 1000.0)
+    premium_ad_spend_schedule: AdSpendSchedule = AdSpendSchedule.constant(0.0)
     ad_manager_monthly_fee: float = 1500.0
     # Diminishing returns parameters for paid acquisition
     adstock_lambda: float = 0.5  # carryover of prior ad effectiveness

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -87,4 +87,56 @@ def test_paid_acquisition_has_diminishing_returns_with_adstock():
     assert max(paid_new) < 10000
 
 
+def test_premium_paid_acquisition_uses_separate_cac():
+    inputs = SimulationInputs(
+        starting_free_subscribers=0,
+        starting_premium_subscribers=0,
+        horizon_months=1,
+        organic_monthly_growth_rate=0.0,
+        monthly_churn_rate_free=0.0,
+        monthly_churn_rate_premium=0.0,
+        new_subscriber_premium_conv_rate=0.0,
+        ongoing_premium_conv_rate=0.0,
+        cost_per_new_free_subscriber=1_000_000.0,
+        cost_per_new_premium_subscriber=10.0,
+        ad_spend_schedule=AdSpendSchedule.constant(0.0),
+        premium_ad_spend_schedule=AdSpendSchedule.constant(1000.0),
+        ad_manager_monthly_fee=0.0,
+        adstock_lambda=0.0,
+        ad_log_theta=1.0,
+    )
+
+    result = simulate_growth(inputs)
+    df = result.monthly
+    assert int(df["new_free_paid"].iloc[0]) == 0
+    assert df["new_premium_paid"].iloc[0] > 0
+    assert df["ad_spend"].iloc[0] == 1000
+    assert df["ad_spend_premium"].iloc[0] == 1000
+
+
+def test_carrying_capacities_are_segment_specific():
+    inputs = SimulationInputs(
+        starting_free_subscribers=500,
+        starting_premium_subscribers=0,
+        carrying_capacity_free=1_000.0,
+        carrying_capacity_premium=50.0,
+        horizon_months=6,
+        organic_monthly_growth_rate=0.5,
+        monthly_churn_rate_free=0.0,
+        monthly_churn_rate_premium=0.0,
+        new_subscriber_premium_conv_rate=0.5,
+        ongoing_premium_conv_rate=0.0,
+        cost_per_new_free_subscriber=0.0,
+        ad_spend_schedule=AdSpendSchedule.constant(0.0),
+        ad_manager_monthly_fee=0.0,
+    )
+
+    result = simulate_growth(inputs)
+    df = result.monthly
+    # Premium subscribers should be capped by the premium capacity
+    assert df["premium_subscribers"].max() <= 50
+    # Free base should still be able to grow toward its own ceiling
+    assert df["free_subscribers"].max() > 900
+
+
 # end


### PR DESCRIPTION
## Summary
- add simulator sidebar inputs for premium-direct CAC/ad spend and optional segment carrying capacities
- surface split CAC and spend metrics for free vs premium acquisitions in KPI tiles

## Testing
- pytest tests/test_model.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cf1e3b34483279d729eacbb76aef5)