### PR TITLE
Fix indentation for event rule layers

### DIFF
--- a/app.py
+++ b/app.py
@@ -214,15 +214,15 @@ def _event_rules_from_events() -> alt.Chart | None:
     ev_p = ev2[ev2.get("effect_norm") == "Persistent"]
     if not ev_p.empty:
         logger.info("Adding persistent event rules")
-            layers.append(
-                alt.Chart(ev_p)
-                .mark_rule(strokeWidth=2, color="#27ae60")
-                .encode(
-                    x=alt.X("marker_date:T", title="Date (monthly)"),
-                    tooltip=[
-                        alt.Tooltip("date:T", title="Date"),
-                        alt.Tooltip("type:N", title="Type"),
-                        alt.Tooltip("effect_norm:N", title="Effect"),
+        layers.append(
+            alt.Chart(ev_p)
+            .mark_rule(strokeWidth=2, color="#27ae60")
+            .encode(
+                x=alt.X("marker_date:T", title="Date (monthly)"),
+                tooltip=[
+                    alt.Tooltip("date:T", title="Date"),
+                    alt.Tooltip("type:N", title="Type"),
+                    alt.Tooltip("effect_norm:N", title="Effect"),
                     alt.Tooltip("notes:N", title="Notes"),
                     alt.Tooltip("cost:Q", title="Cost ($)"),
                 ],
@@ -232,15 +232,15 @@ def _event_rules_from_events() -> alt.Chart | None:
     ev_t = ev2[ev2.get("effect_norm") == "Transient"]
     if not ev_t.empty:
         logger.info("Adding transient event rules")
-            layers.append(
-                alt.Chart(ev_t)
-                .mark_rule(strokeWidth=2, color="#8e44ad", strokeDash=[6, 4])
-                .encode(
-                    x=alt.X("marker_date:T", title="Date (monthly)"),
-                    tooltip=[
-                        alt.Tooltip("date:T", title="Date"),
-                        alt.Tooltip("type:N", title="Type"),
-                        alt.Tooltip("effect_norm:N", title="Effect"),
+        layers.append(
+            alt.Chart(ev_t)
+            .mark_rule(strokeWidth=2, color="#8e44ad", strokeDash=[6, 4])
+            .encode(
+                x=alt.X("marker_date:T", title="Date (monthly)"),
+                tooltip=[
+                    alt.Tooltip("date:T", title="Date"),
+                    alt.Tooltip("type:N", title="Type"),
+                    alt.Tooltip("effect_norm:N", title="Effect"),
                     alt.Tooltip("notes:N", title="Notes"),
                     alt.Tooltip("cost:Q", title="Cost ($)"),
                 ],
@@ -250,15 +250,15 @@ def _event_rules_from_events() -> alt.Chart | None:
     ev_n = ev2[ev2.get("effect_norm") == "No effect"]
     if not ev_n.empty:
         logger.info("Adding no effect event rules")
-            layers.append(
-                alt.Chart(ev_n)
-                .mark_rule(strokeWidth=2, color="#bdc3c7", strokeDash=[2, 4])
-                .encode(
-                    x=alt.X("marker_date:T", title="Date (monthly)"),
-                    tooltip=[
-                        alt.Tooltip("date:T", title="Date"),
-                        alt.Tooltip("type:N", title="Type"),
-                        alt.Tooltip("effect_norm:N", title="Effect"),
+        layers.append(
+            alt.Chart(ev_n)
+            .mark_rule(strokeWidth=2, color="#bdc3c7", strokeDash=[2, 4])
+            .encode(
+                x=alt.X("marker_date:T", title="Date (monthly)"),
+                tooltip=[
+                    alt.Tooltip("date:T", title="Date"),
+                    alt.Tooltip("type:N", title="Type"),
+                    alt.Tooltip("effect_norm:N", title="Effect"),
                     alt.Tooltip("notes:N", title="Notes"),
                     alt.Tooltip("cost:Q", title="Cost ($)"),
                 ],


### PR DESCRIPTION
## Summary
- fix indentation in event rule layer construction to resolve script compilation errors
- keep event rule tooltips and styling intact for persistent, transient, and no-effect events

## Testing
- python -m compileall app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d0832c388832787ba1176319ba5ef)