### PR TITLE
Add premium downgrade flow into free segment

### DIFF
--- a/analysis/sim_once_1000_m1_explanation.md
+++ b/analysis/sim_once_1000_m1_explanation.md
@@ -18,7 +18,7 @@ This is the month-by-month operational projection that the simulator emits. Key 
 
 ### Monthly flows
 - `new_free_organic` and `new_free_paid` represent the inbound free subscribers each month. Month 1’s paid-acquired joins are still derived from the $1,000 spend at a $2 CAC, but the carrying-capacity factor now dampens how many of those signups “stick.” From month 2 onward only the organic channel contributes, and those gains taper as the base approaches saturation.【F:analysis/sim_once_1000_m1_explanation.md†L21-L25】
-- `free_churned` shows cancellations among free readers; `premium_converted_from_new` and `premium_converted_from_existing` convert a slice of the free base into paying members; `premium_churned` removes paying subscribers. All conversions start at zero from the new-acquisition cohort and slowly increase as the free base scales, while churn stays very low relative to gross adds in this scenario.【F:analysis/sim_once_1000_m1_explanation.md†L27-L30】
+- `free_churned` shows cancellations among free readers; `premium_converted_from_new` and `premium_converted_from_existing` convert a slice of the free base into paying members; `premium_downgraded_to_free` captures paid users who cancel but stay subscribed as free readers; `premium_churned` removes paying subscribers entirely. All conversions start at zero from the new-acquisition cohort and slowly increase as the free base scales, while churn stays very low relative to gross adds in this scenario.【F:analysis/sim_once_1000_m1_explanation.md†L27-L30】
 
 ### Spend and fees
 - `ad_spend` and `ad_manager_fee` capture marketing outlay. Only month 1 shows the $1,000 spend; subsequent months stay at zero because this is a single-shot campaign.【F:analysis/sim_once_1000_m1_explanation.md†L33-L34】

--- a/app.py
+++ b/app.py
@@ -1457,6 +1457,15 @@ def sidebar_inputs() -> SimulationInputs:
             format="%0.3f",
             key="churn_prem",
         )
+        downgrade_to_free = number_input_state(
+            "Paid downgrades to free",
+            min_value=0.0,
+            max_value=1.0,
+            default_value=float(_get_state("downgrade_to_free", 0.0)),
+            step=0.001,
+            format="%0.3f",
+            key="downgrade_to_free",
+        )
 
     with st.sidebar.expander("Conversions", expanded=True):
         conv_new = number_input_state(
@@ -1854,6 +1863,7 @@ def sidebar_inputs() -> SimulationInputs:
         organic_monthly_growth_rate=organic_from_fit,
         monthly_churn_rate_free=float(churn_free),
         monthly_churn_rate_premium=float(churn_prem),
+        monthly_downgrade_rate_premium=float(downgrade_to_free),
         new_subscriber_premium_conv_rate=float(conv_new),
         ongoing_premium_conv_rate=float(conv_ongoing),
         cost_per_new_free_subscriber=float(cac),

--- a/substack_analyzer/model.py
+++ b/substack_analyzer/model.py
@@ -46,6 +46,7 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         "free_churned",
         "premium_converted_from_new",
         "premium_converted_from_existing",
+        "premium_downgraded_to_free",
         "premium_churned",
         "ad_spend",
         "ad_spend_free",
@@ -75,9 +76,11 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         # Beginning-of-month churn
         free_churned = free_subs * input_params.monthly_churn_rate_free
         premium_churned = premium_subs * input_params.monthly_churn_rate_premium
+        premium_downgraded_to_free = premium_subs * input_params.monthly_downgrade_rate_premium
 
-        free_subs -= free_churned
-        premium_subs -= premium_churned
+        free_subs = max(free_subs - free_churned, 0.0)
+        premium_subs = max(premium_subs - premium_churned - premium_downgraded_to_free, 0.0)
+        free_subs += premium_downgraded_to_free
 
         # Capacity pressure: scale organic/paid acquisition as the audience
         # approaches the inferred carrying capacity (if provided). Prefer
@@ -218,6 +221,7 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
                 free_churned,
                 convert_from_new,
                 convert_from_existing,
+                premium_downgraded_to_free,
                 premium_churned,
                 ad_spend_total,
                 ad_spend_free,
@@ -245,6 +249,7 @@ def simulate_growth(input_params: SimulationInputs) -> SimulationResult:
         "free_churned",
         "premium_converted_from_new",
         "premium_converted_from_existing",
+        "premium_downgraded_to_free",
         "premium_churned",
         "new_premium_paid",
     ]

--- a/substack_analyzer/types.py
+++ b/substack_analyzer/types.py
@@ -93,6 +93,7 @@ class SimulationInputs:
     organic_monthly_growth_rate: float = DEFAULT_GROWTH_RATE
     monthly_churn_rate_free: float = 0.01  # 1%
     monthly_churn_rate_premium: float = 0.01  # 1%
+    monthly_downgrade_rate_premium: float = 0.0  # share of premium who step down to free
 
     # Conversions
     new_subscriber_premium_conv_rate: float = 0.02  # 2% of new free subs

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -139,4 +139,31 @@ def test_carrying_capacities_are_segment_specific():
     assert df["free_subscribers"].max() > 900
 
 
+def test_premium_downgrades_move_to_free_instead_of_churning_out():
+    inputs = SimulationInputs(
+        starting_free_subscribers=0,
+        starting_premium_subscribers=100,
+        horizon_months=1,
+        organic_monthly_growth_rate=0.0,
+        monthly_churn_rate_free=0.0,
+        monthly_churn_rate_premium=0.0,
+        monthly_downgrade_rate_premium=0.1,
+        new_subscriber_premium_conv_rate=0.0,
+        ongoing_premium_conv_rate=0.0,
+        cost_per_new_free_subscriber=0.0,
+        ad_spend_schedule=AdSpendSchedule.constant(0.0),
+        ad_manager_monthly_fee=0.0,
+    )
+
+    result = simulate_growth(inputs)
+    df = result.monthly
+
+    # 10 premium subscribers downgrade to free; none churn out, so totals stay constant
+    assert df["premium_downgraded_to_free"].iloc[0] == 10
+    assert df["premium_churned"].iloc[0] == 0
+    assert df["free_subscribers"].iloc[0] == 10
+    assert df["premium_subscribers"].iloc[0] == 90
+    assert df["total_subscribers"].iloc[0] == 100
+
+
 # end


### PR DESCRIPTION
## Summary
- add a configurable premium downgrade rate that moves canceling payers into the free pool and tracks the flow in outputs
- expose the downgrade parameter on SimulationInputs and keep flow rounding/columns aligned
- document the new flow in the scenario walkthrough and cover it with a regression test
- add a sidebar control for paid downgrades to feed the new rate into simulations

## Testing
- python -m pytest tests/test_model.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2c54ac188327a93c04bedeb57fa7)