### PR TITLE
Update documentation for current pipeline and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## How to use
 
-Open the hosted app: https://substackanalyzer.streamlit.app/ (just click to wake it up if it's gone to sleep)
+Open the hosted app: https://substackanalyzer.streamlit.app/ (just click to wake it up if it's gone to sleep). The Streamlit UI walks through Phase 1 (fit and diagnostics) and Phase 2 (simulation and outputs) with inline downloads and a Save / Load tab for session bundles.
 
 ### Headless (Python-only) runner
 
-You can run the core pipeline from CSV/XLSX files without the UI:
+You can run the Phase 1 pipeline from CSV/XLSX files without the UI:
 
 ```bash
 python scripts/run_headless.py \
@@ -14,16 +14,24 @@ python scripts/run_headless.py \
   --paid /path/to/paid.csv --paid-has-header --paid-date-col 0 --paid-count-col 1 \
   --events /path/to/events.csv \
   --adspend /path/to/ad_spend.csv \
-  --max-changes 4 --lam 0.5 --theta 500 \
+  --max-changes 4 --detect-on auto --detector classifier \
+  --lam 0.5 --theta 500 \
   --out-dir ./outputs
 ```
 
 Notes:
 
-- `--all` and/or `--paid` should each point to a two-column file (date, count). Use `--*-has-header` and `--*-date-col`/`--*-count-col` to specify header presence and column indices or names.
-- `--events` (optional) CSV columns: `date`, `type`, `persistence`, `cost`.
-- `--adspend` (optional) CSV/XLSX columns: `date`, `spend`.
-- Outputs include `summary.json`, `fitted_series.csv`, `features.csv`, and `covariates.csv` in `--out-dir`.
+- Provide at least one of `--all` or `--paid`. Each should point to a two-column file (date, count). Use `--*-has-header` and `--*-date-col`/`--*-count-col` to specify header presence and column indices or names.
+- `--events` (optional) CSV columns: `date`, `type`, `persistence`, `cost`. Events are encoded as pulse/step regressors for the logistic fit and saved to `events_normalized.csv` if present.
+- `--adspend` (optional) CSV/XLSX columns: `date`, `spend`. The ad stock/log-response parameters (`--lam`, `--theta`) control the exogenous regressor used in the fit.
+- Change-point detection matches the Streamlit app: `--detector classifier` (default) or `--detector simple`, `--detect-on` for total/paid/free/both, plus `--min-seg-len`, `--penalty-scale`, `--window`, and `--z-pulse` tuning knobs. Add `--keep-all-breaks` to skip classifier-based filtering of persistent breakpoints.
+- Outputs in `--out-dir` include:
+  - `summary.json`: detected breakpoints, fit parameters, fit diagnostics, and derived estimates.
+  - `fitted_series.csv`: deterministic piecewise-logistic fit on the supplied cadence.
+  - `covariates.csv` / `features.csv`: engineered regressors used in the fit.
+  - `events_normalized.csv`: cleaned events used for encoding (when provided).
+  - `equation.md`: human-readable growth equation with parameters and inputs.
+  - `phase1.json`: the portable artifact you can load into the app to proceed to the simulator.
 
 ## What this does
 

--- a/scripts/output.md
+++ b/scripts/output.md
@@ -1,13 +1,12 @@
-output.md
+## Headless output bundle
 
-How to read the results
+Running `python scripts/run_headless.py ... --out-dir ./outputs` produces the same Phase 1 artifacts that the Streamlit app saves. Key files:
 
-gamma_pulse/gamma_step of 0 - no events provided
-gamma_exog - 0 - effect of exogenous ad feature
-
- "gamma_intercept": 0.5010767236155675, - constant monthly drift
-
-"sse": 5782142.468140559,
-  "r2_on_deltas": -0.1951464187657619, - fit metrics
+- `summary.json` – detector configuration, chosen breakpoints, fit parameters (`carrying_capacity`, `segment_growth_rates`, `segment_intercepts`, `gamma_*`), and fit diagnostics (`sse`, `r2_on_deltas`). It also includes the derived adds/churn estimates used for downstream stages.
+- `fitted_series.csv` – deterministic piecewise-logistic fit at the supplied cadence with a `fitted` column.
+- `features.csv` and `covariates.csv` – engineered regressors: adstocked/log ad response plus pulse/step encodings from events.
+- `events_normalized.csv` – cleaned event table with normalized types, persistence, and optional cost; only emitted when an events CSV was supplied.
+- `equation.md` – the rendered growth equation with the fitted parameters and the inputs that fed the model.
+- `phase1.json` – portable artifact that you can load into the app (Stage 2) to continue with simulation without re-running the fit.
 
 

--- a/substack_analyzer/faq.py
+++ b/substack_analyzer/faq.py
@@ -10,7 +10,9 @@ FAQ_ITEMS = [
             "- **Cumulative profit**: Sum of monthly profit (net revenue minus ad spend and ad manager fee) over time.\n"
             "- **Cumulative ad spend**: Total advertising spend across all simulated months.\n"
             "- **ROAS (net revenue / ad spend)**: Net revenue divided by total ad spend, showing revenue efficiency of ads.\n"
-            "- **Blended CAC (paid only)**: Total ad spend divided by the number of new free subscribers attributed to ads.\n"
+            "- **Blended free CAC (paid only)**: Free-attributed ad spend divided by the number of new free subscribers tagged as paid.\n"
+            "- **Blended premium CAC (paid only)**: Premium-attributed ad spend divided by premium subscribers added via paid campaigns.\n"
+            "- **Premium ad spend / Free ad spend**: Breakdown of the spend allocated to premium versus free acquisition schedules.\n"
             "- **Payback month (cumulative)**: First month where cumulative profit turns positive.\n"
             "- **Ad manager fee**: Monthly management fee applied only in months with ad spend; it reduces monthly profit."
         ),


### PR DESCRIPTION
## Summary
- refresh README with current headless options, outputs, and app phases
- update FAQ metric descriptions to match the latest KPI tiles
- document the headless output bundle generated by scripts/run_headless.py

## Testing
- not run (docs-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d06b18ab08327bc7cd496f89746c0)