### PR TITLE
Fix series reconstruction alignment

### DIFF
--- a/substack_analyzer/persistence.py
+++ b/substack_analyzer/persistence.py
@@ -260,12 +260,14 @@ def _records_to_series(records: list[dict[str, Any]] | None) -> pd.Series | None
     if not {"date", "count"}.issubset(df.columns):
         return None
     df = df.assign(date=lambda d: pd.to_datetime(d["date"]))
-    df = df.dropna(subset=["date"]).sort_values("date")
-    s = pd.to_numeric(df["count"], errors="coerce").dropna()
-    if s.empty:
+    # Keep rows where both date and count are valid; ensure alignment after dropna
+    counts = pd.to_numeric(df["count"], errors="coerce")
+    df = df.loc[counts.notna()].dropna(subset=["date"]).copy()
+    if df.empty:
         return None
-    s.index = df["date"].dt.to_period("M").dt.to_timestamp("M")
-    return pd.Series(s.values, index=s.index)
+    df = df.sort_values("date")
+    idx = df["date"].dt.to_period("M").dt.to_timestamp("M")
+    return pd.Series(counts.loc[df.index].astype(float).values, index=idx)
 
 
 def _detect_display_to_code(value: str) -> str:


### PR DESCRIPTION
## Summary
- ensure `_records_to_series` aligns dates with valid count rows when rebuilding series
- prevent length mismatches by filtering invalid counts before assigning a normalized index

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dd0f06608327af2a1f2c847d0218)