### PR TITLE
Clear dual fit state when disabled

### DIFF
--- a/app.py
+++ b/app.py
@@ -978,6 +978,8 @@ def quick_fit_ui(plot_df: pd.DataFrame, breakpoints: list[int]) -> None:
                 fit = dual_fit.free_fit
                 st.session_state["pwlog_fit"] = fit
             else:
+                # Clear any previous dual-fit when it is disabled or unavailable
+                st.session_state.pop("dual_fit", None)
                 fit = fit_piecewise_logistic(
                     total_series=fit_series_source,
                     breakpoints=breakpoints,


### PR DESCRIPTION
## Summary
- remove stale dual-series fit from session state when the feature is disabled or unavailable
- ensure single-series fits no longer carry over inferred parameters from prior dual fits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dff8bc24832793c1ef00b2afd0b0)